### PR TITLE
Increase max debounce time to max login time

### DIFF
--- a/src/main/java/com/adamk33n3r/runelite/watchdog/ui/panels/AlertPanel.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/ui/panels/AlertPanel.java
@@ -278,7 +278,7 @@ public class AlertPanel extends PluginPanel {
                 alert.getDebounceTime(),
                 alert::setDebounceTime,
                 0,
-                60000,
+                8640000, // 6 hours - max time a player can be logged in
                 100
             );
     }


### PR DESCRIPTION
Fixes #77 

I took a shot at the max reasonable value being the longest a character can be logged in. Any value beyond this wouldn't make sense so this is effectively unbounded without being infinity.