### PR TITLE
fix: Tray Notifications on Linux & macOS

### DIFF
--- a/src/main/java/com/adamk33n3r/runelite/watchdog/TrayNotifier.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/TrayNotifier.java
@@ -8,6 +8,7 @@ import net.runelite.api.Client;
 import net.runelite.client.RuneLite;
 import net.runelite.client.RuneLiteProperties;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.util.OSType;
 
@@ -45,7 +46,8 @@ public class TrayNotifier {
     @Inject
     protected transient ConfigManager configManager;
     private static final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(2);
-    private final transient FakeRuneLiteConfig runeLiteConfig;
+    @Inject
+    private transient RuneLiteConfig runeLiteConfig;
     private transient final String appName = "RuneLite";
     // Copied from RuneLite's Notifier class
     private final transient Path notifyIconPath = RuneLite.RUNELITE_DIR.toPath().resolve("icon.png");
@@ -56,8 +58,6 @@ public class TrayNotifier {
             .build();
 
     public TrayNotifier() {
-        this.runeLiteConfig = new FakeRuneLiteConfig(this);
-
         // Copied from RuneLite's Notifier class
         // Check if we are running in the launcher because terminal-notifier notifications don't work
         // if the group/sender are unknown to it.
@@ -237,23 +237,4 @@ public class TrayNotifier {
         }
     }
 
-    /**
-     * This "mocks" the RuneLite config
-     * While this isn't necessarily efficient, it means we don't have to make any modification to the copied code
-     */
-    private static class FakeRuneLiteConfig {
-        private final TrayNotifier parent;
-
-        public FakeRuneLiteConfig(TrayNotifier parent) {
-            this.parent = parent;
-        }
-
-        int notificationTimeout() {
-            Integer notificationTimeout = this.parent.configManager.getConfiguration("runelite", "notificationTimeout", Integer.class);
-            if (notificationTimeout == null) {
-                return 10000;
-            }
-            return notificationTimeout;
-        }
-    }
 }

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/TrayNotifier.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/TrayNotifier.java
@@ -1,0 +1,259 @@
+package com.adamk33n3r.runelite.watchdog;
+
+import com.google.common.base.Strings;
+import com.google.common.escape.Escaper;
+import com.google.common.escape.Escapers;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.client.RuneLite;
+import net.runelite.client.RuneLiteProperties;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.ui.ClientUI;
+import net.runelite.client.util.OSType;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.awt.*;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This file is as-much-as-possible a copy of {@link net.runelite.client.Notifier}
+ * The copied functions can be run through a differ on Notifier's versions of the functions
+ */
+@Slf4j
+@Singleton
+public class TrayNotifier {
+    @Inject
+    protected transient ClientUI clientUI;
+
+    @Inject
+    protected transient Client client;
+
+    @Inject
+    protected transient AlertManager alertManager;
+
+    @Inject
+    protected transient WatchdogConfig watchdogConfig;
+
+    @Inject
+    protected transient ConfigManager configManager;
+    private static final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(2);
+    private final transient FakeRuneLiteConfig runeLiteConfig;
+    private transient final String appName = "RuneLite";
+    // Copied from RuneLite's Notifier class
+    private final transient Path notifyIconPath = RuneLite.RUNELITE_DIR.toPath().resolve("icon.png");
+    private transient boolean terminalNotifierAvailable;
+    private static final String DOUBLE_QUOTE = "\"";
+    private static final Escaper SHELL_ESCAPE = Escapers.builder()
+            .addEscape('"', "'")
+            .build();
+
+    public TrayNotifier() {
+        this.runeLiteConfig = new FakeRuneLiteConfig(this);
+
+        // Copied from RuneLite's Notifier class
+        // Check if we are running in the launcher because terminal-notifier notifications don't work
+        // if the group/sender are unknown to it.
+        if (!Strings.isNullOrEmpty(RuneLiteProperties.getLauncherVersion()) && OSType.getOSType() == OSType.MacOS)
+        {
+            executorService.execute(() -> {
+                terminalNotifierAvailable = isTerminalNotifierAvailable();
+            });
+        }
+    }
+
+    public void notify(
+            final String title,
+            final String message,
+            final TrayIcon.MessageType type)
+    {
+        this.sendNotification(title, message, type);
+    }
+
+    // Copy of RuneLite's Notifier::sendNotification
+    private void sendNotification(
+            final String title,
+            final String message,
+            final TrayIcon.MessageType type)
+    {
+        final String escapedTitle = SHELL_ESCAPE.escape(title);
+        final String escapedMessage = SHELL_ESCAPE.escape(message);
+
+        switch (OSType.getOSType())
+        {
+            case Linux:
+                sendLinuxNotification(escapedTitle, escapedMessage, type);
+                break;
+            case MacOS:
+                sendMacNotification(escapedTitle, escapedMessage);
+                break;
+            default:
+                sendTrayNotification(title, message, type);
+        }
+    }
+
+    // Copy of RuneLite's Notifier::sendTrayNotification
+    private void sendTrayNotification(
+            final String title,
+            final String message,
+            final TrayIcon.MessageType type)
+    {
+        if (clientUI.getTrayIcon() != null)
+        {
+            clientUI.getTrayIcon().displayMessage(title, message, type);
+        }
+    }
+
+    // Copy of RuneLite's Notifier::sendLinuxNotification
+    private void sendLinuxNotification(
+            final String title,
+            final String message,
+            final TrayIcon.MessageType type)
+    {
+        final List<String> commands = new ArrayList<>();
+        commands.add("notify-send");
+        commands.add(title);
+        commands.add(message);
+        commands.add("-a");
+        commands.add(SHELL_ESCAPE.escape(appName));
+        commands.add("-i");
+        commands.add(SHELL_ESCAPE.escape(notifyIconPath.toAbsolutePath().toString()));
+        commands.add("-u");
+        commands.add(toUrgency(type));
+        if (runeLiteConfig.notificationTimeout() > 0)
+        {
+            commands.add("-t");
+            commands.add(String.valueOf(runeLiteConfig.notificationTimeout()));
+        }
+
+        executorService.submit(() ->
+        {
+            try
+            {
+                Process notificationProcess = sendCommand(commands);
+
+                boolean exited = notificationProcess.waitFor(500, TimeUnit.MILLISECONDS);
+                if (exited && notificationProcess.exitValue() == 0)
+                {
+                    return;
+                }
+            }
+            catch (IOException | InterruptedException ex)
+            {
+                log.debug("error sending notification", ex);
+            }
+
+            // fall back to tray notification
+            sendTrayNotification(title, message, type);
+        });
+    }
+
+    // Copy of RuneLite's Notifier::sendMacNotification
+    private void sendMacNotification(final String title, final String message)
+    {
+        final List<String> commands = new ArrayList<>();
+
+        if (terminalNotifierAvailable)
+        {
+            Collections.addAll(commands,
+                    "sh", "-lc", "\"$@\"", "--",
+                    "terminal-notifier",
+                    "-title", title,
+                    "-message", message,
+                    "-group", "net.runelite.launcher",
+                    "-sender", "net.runelite.launcher"
+            );
+        }
+        else
+        {
+            commands.add("osascript");
+            commands.add("-e");
+
+            final String script = "display notification " + DOUBLE_QUOTE +
+                    message +
+                    DOUBLE_QUOTE +
+                    " with title " +
+                    DOUBLE_QUOTE +
+                    title +
+                    DOUBLE_QUOTE;
+
+            commands.add(script);
+        }
+
+        try
+        {
+            sendCommand(commands);
+        }
+        catch (IOException ex)
+        {
+            log.warn("error sending notification", ex);
+        }
+    }
+
+    // Copy of RuneLite's Notifier::sendCommand
+    private static Process sendCommand(final List<String> commands) throws IOException
+    {
+        return new ProcessBuilder(commands)
+                .redirectErrorStream(true)
+                .start();
+    }
+
+    // Copy of RuneLite's Notifier::isTerminalNotifierAvailable
+    private boolean isTerminalNotifierAvailable()
+    {
+        try
+        {
+            // The PATH seen by Cocoa apps does not resemble that seen by the shell, so we defer to the latter.
+            final Process exec = Runtime.getRuntime().exec(new String[]{"sh", "-lc", "terminal-notifier -help"});
+            if (!exec.waitFor(2, TimeUnit.SECONDS))
+            {
+                return false;
+            }
+            return exec.exitValue() == 0;
+        }
+        catch (IOException | InterruptedException e)
+        {
+            return false;
+        }
+    }
+
+    // Copy of RuneLite's Notifier::toUrgency
+    private static String toUrgency(TrayIcon.MessageType type)
+    {
+        switch (type)
+        {
+            case WARNING:
+            case ERROR:
+                return "critical";
+            default:
+                return "normal";
+        }
+    }
+
+    /**
+     * This "mocks" the RuneLite config
+     * While this isn't necessarily efficient, it means we don't have to make any modification to the copied code
+     */
+    private static class FakeRuneLiteConfig {
+        private final TrayNotifier parent;
+
+        public FakeRuneLiteConfig(TrayNotifier parent) {
+            this.parent = parent;
+        }
+
+        int notificationTimeout() {
+            Integer notificationTimeout = this.parent.configManager.getConfiguration("runelite", "notificationTimeout", Integer.class);
+            if (notificationTimeout == null) {
+                return 10000;
+            }
+            return notificationTimeout;
+        }
+    }
+}

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/TrayNotifier.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/TrayNotifier.java
@@ -20,7 +20,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -45,7 +44,8 @@ public class TrayNotifier {
 
     @Inject
     protected transient ConfigManager configManager;
-    private static final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(2);
+    @Inject
+    private transient ScheduledExecutorService executorService;
     @Inject
     private transient RuneLiteConfig runeLiteConfig;
     private transient final String appName = "RuneLite";

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/WatchdogPlugin.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/WatchdogPlugin.java
@@ -102,9 +102,6 @@ public class WatchdogPlugin extends Plugin {
 
     private NavigationButton navButton;
 
-    @Inject
-    private final TrayNotifier trayNotifier = new TrayNotifier();
-
     @Getter
     private static WatchdogPlugin instance;
 

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/WatchdogPlugin.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/WatchdogPlugin.java
@@ -102,6 +102,9 @@ public class WatchdogPlugin extends Plugin {
 
     private NavigationButton navButton;
 
+    @Inject
+    private final TrayNotifier trayNotifier = new TrayNotifier();
+
     @Getter
     private static WatchdogPlugin instance;
 

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/notifications/TrayNotification.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/notifications/TrayNotification.java
@@ -1,5 +1,6 @@
 package com.adamk33n3r.runelite.watchdog.notifications;
 
+import com.adamk33n3r.runelite.watchdog.TrayNotifier;
 import com.adamk33n3r.runelite.watchdog.Util;
 import com.adamk33n3r.runelite.watchdog.WatchdogConfig;
 
@@ -13,17 +14,18 @@ import java.awt.TrayIcon;
 @NoArgsConstructor
 public class TrayNotification extends MessageNotification {
     @Inject
+    protected transient TrayNotifier trayNotifier;
+
+    @Inject
     public TrayNotification(WatchdogConfig config) {
         super(config);
     }
 
     @Override
     protected void fireImpl(String[] triggerValues) {
-        if (this.clientUI.getTrayIcon() != null) {
-            this.clientUI.getTrayIcon().displayMessage(
+        this.trayNotifier.notify(
                 "Watchdog",
                 Util.processTriggerValues(this.message, triggerValues),
                 TrayIcon.MessageType.NONE);
-        }
     }
 }


### PR DESCRIPTION
Based on a conversation in the RuneLite Discord here https://discord.com/channels/301497432909414422/419891709883973642/1175876740262936606
it seemed best to copy and paste the implementation for now, rather than
making the necessary parts public in RuneLite's Notifier.

I've kept the functions as unchanged as possible to make TrayNotifier
easy to diff & review

I have tested this on Linux, and I'll test this on one macOS setup soon as well

The PR is ready for a brief look into how I'm solving it (I'm not an experienced Java developer), but I think the general idea will stay the same.
