### PR TITLE
Increase overlay ttl max to 999

### DIFF
--- a/src/main/java/com/adamk33n3r/runelite/watchdog/ui/notifications/panels/OverlayNotificationPanel.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/ui/notifications/panels/OverlayNotificationPanel.java
@@ -76,7 +76,7 @@ public class OverlayNotificationPanel extends MessageNotificationPanel {
         });
         this.settings.add(sticky);
 
-        JSpinner displayTime = PanelUtils.createSpinner(notification.getTimeToLive(), 1, 99, 1, val -> {
+        JSpinner displayTime = PanelUtils.createSpinner(notification.getTimeToLive(), 1, 999, 1, val -> {
             notification.setTimeToLive(val);
             onChangeListener.run();
         });


### PR DESCRIPTION
Fixes #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced notification system by allowing users to set a longer display time for notifications, increasing the upper limit from 99 to 999 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->