### PR TITLE
Update README badges to api.runelite.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Guard_dog_resize](https://user-images.githubusercontent.com/1350444/149637084-270521ab-2d96-4c54-a7b4-71357fb6b291.png)
 
 # Watchdog
-[![Plugin Hub](https://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/watchdog)](https://runelite.net/plugin-hub/show/watchdog)
+[![Plugin Hub](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/watchdog)](https://runelite.net/plugin-hub/show/watchdog)
 [![Discord](https://img.shields.io/discord/1064234152314015875?color=%235865F2&label=Watchdog&logo=discord&logoColor=white&style=flat)](https://discord.gg/n8mxYAHJR9)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/T6T0JH18I)


### PR DESCRIPTION
The website [i.pluginhub.info](https://i.pluginhub.info), which powers your README badges, is going to be shut down at the end of the month (November 1st, 2024) as you can now use RuneLite's API to generate these shields (as was done in this PR).

I highly recommend you merge this PR, or make this change yourself, before the shutdown date to avoid your badges breaking.

You should also create a PR to the hub so that your readme updates on [RuneLite.net's Plugin Hub](https://runelite.net/plugin-hub/show/runelite-watchdog) website after merging this PR, but that's up to you

Anyway, thanks for using my website while it was alive :heart:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Plugin Hub badge URL in the README.md to reflect accurate installation statistics for the Watchdog plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->