### PR TITLE
fix: only disable watchdog in hydra instance

### DIFF
--- a/src/main/java/com/adamk33n3r/runelite/watchdog/Region.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/Region.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 
 // Use https://explv.github.io to find region ids
 public enum Region {
-    ALCHEMICAL_HYDRA(5536),
+    ALCHEMICAL_HYDRA(true, 5536),
     VARDORVIS(4405),
     LEVIATHAN(8291),
     WHISPERER(10595),
@@ -57,14 +57,21 @@ public enum Region {
 //    )
     ;
 
+    public final boolean onlyInInstance;
     public final int[] regionIDs;
 
     Region(int... regionIDs) {
+        this(false, regionIDs);
+    }
+
+    Region(boolean onlyInInstance, int... regionIDs) {
+        this.onlyInInstance = onlyInInstance;
         this.regionIDs = regionIDs;
     }
 
-    public static boolean isBannedRegion(int regionID) {
+    public static boolean isBannedRegion(boolean inInstance, int regionID) {
         return Arrays.stream(values())
+            .filter(r -> inInstance || !r.onlyInInstance)
             .flatMapToInt(r -> Arrays.stream(r.regionIDs))
             .anyMatch(id -> id == regionID);
     }

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/WatchdogPlugin.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/WatchdogPlugin.java
@@ -204,7 +204,7 @@ public class WatchdogPlugin extends Plugin {
     private void onGameTick(GameTick gameTick) {
         int regionID = WorldPoint.fromLocalInstance(this.client, this.client.getLocalPlayer().getLocalLocation()).getRegionID();
         boolean before = this.isInBannedArea;
-        this.isInBannedArea = Region.isBannedRegion(regionID);
+        this.isInBannedArea = Region.isBannedRegion(this.client.getLocalPlayer().getWorldView().isInstance(), regionID);
 //            || this.client.getVarbitValue(Varbits.IN_RAID) > 0
 //            || this.client.getVarbitValue(Varbits.TOA_RAID_LEVEL) > 0
 //            || this.client.getVarbitValue(Varbits.THEATRE_OF_BLOOD) > 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced region detection logic to consider whether the player is in an instance when checking for banned areas.
  
- **Bug Fixes**
	- Improved accuracy of banned area detection, ensuring better compliance with game rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->