### PR TITLE
Make `Dismiss Overlay` notifications work for non-sticky overlays

### DIFF
--- a/src/main/java/com/adamk33n3r/runelite/watchdog/NotificationOverlay.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/NotificationOverlay.java
@@ -126,7 +126,7 @@ public class NotificationOverlay extends OverlayPanel {
 
     public void clearById(String id) {
         List<OverlayNotificationData> stickiesToDismiss = this.overlayNotificationQueue.stream()
-            .filter(notif -> notif.overlayNotification.isSticky() && Objects.equals(notif.overlayNotification.getId(), id))
+            .filter(notif -> Objects.equals(notif.overlayNotification.getId(), id))
             .collect(Collectors.toList());
         this.overlayNotificationQueue.removeAll(stickiesToDismiss);
     }

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/NotificationType.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/NotificationType.java
@@ -28,7 +28,7 @@ public enum NotificationType implements Displayable {
     PLUGIN_TOGGLE("Plugin Toggle", "Toggle a plugin's enabled state", NotificationCategory.ADVANCED, PluginToggle.class),
     DISMISS_OVERLAY("Dismiss Overlay", "Dismiss an overlay by ID", NotificationCategory.ADVANCED, DismissOverlay.class),
     DISMISS_SCREEN_MARKER("Dismiss Screen Marker", "Dismiss a screen marker by ID", NotificationCategory.ADVANCED, DismissScreenMarker.class),
-    DISMISS_OBJECT_MARKER("Dismiss Object Marker", "Dismiss a object marker by ID", NotificationCategory.ADVANCED, DismissObjectMarker.class),
+    DISMISS_OBJECT_MARKER("Dismiss Object Marker", "Dismiss an object marker by ID", NotificationCategory.ADVANCED, DismissObjectMarker.class),
     REQUEST_FOCUS("Request Focus", "Requests focus on the window", NotificationCategory.ADVANCED, RequestFocus.class),
     NOTIFICATION_EVENT("Notification Event", "Fire a NotificationFired event so that other plugins may hook into it e.g. RL Tray Notifications", NotificationCategory.ADVANCED, NotificationEvent.class),
     ;

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/NotificationType.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/NotificationType.java
@@ -26,7 +26,7 @@ public enum NotificationType implements Displayable {
     ALERT_TOGGLE("Alert Toggle", "Toggle an alert's enabled state", NotificationCategory.ADVANCED, AlertToggle.class),
     PLUGIN_MESSAGE("Plugin Message", "Send a message to another plugin", NotificationCategory.ADVANCED, PluginMessage.class),
     PLUGIN_TOGGLE("Plugin Toggle", "Toggle a plugin's enabled state", NotificationCategory.ADVANCED, PluginToggle.class),
-    DISMISS_OVERLAY("Dismiss Overlay", "Dismiss a sticky overlay by ID", NotificationCategory.ADVANCED, DismissOverlay.class),
+    DISMISS_OVERLAY("Dismiss Overlay", "Dismiss an overlay by ID", NotificationCategory.ADVANCED, DismissOverlay.class),
     DISMISS_SCREEN_MARKER("Dismiss Screen Marker", "Dismiss a sticky screen marker by ID", NotificationCategory.ADVANCED, DismissScreenMarker.class),
     DISMISS_OBJECT_MARKER("Dismiss Object Marker", "Dismiss a sticky object marker by ID", NotificationCategory.ADVANCED, DismissObjectMarker.class),
     REQUEST_FOCUS("Request Focus", "Requests focus on the window", NotificationCategory.ADVANCED, RequestFocus.class),

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/NotificationType.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/NotificationType.java
@@ -27,8 +27,8 @@ public enum NotificationType implements Displayable {
     PLUGIN_MESSAGE("Plugin Message", "Send a message to another plugin", NotificationCategory.ADVANCED, PluginMessage.class),
     PLUGIN_TOGGLE("Plugin Toggle", "Toggle a plugin's enabled state", NotificationCategory.ADVANCED, PluginToggle.class),
     DISMISS_OVERLAY("Dismiss Overlay", "Dismiss an overlay by ID", NotificationCategory.ADVANCED, DismissOverlay.class),
-    DISMISS_SCREEN_MARKER("Dismiss Screen Marker", "Dismiss a sticky screen marker by ID", NotificationCategory.ADVANCED, DismissScreenMarker.class),
-    DISMISS_OBJECT_MARKER("Dismiss Object Marker", "Dismiss a sticky object marker by ID", NotificationCategory.ADVANCED, DismissObjectMarker.class),
+    DISMISS_SCREEN_MARKER("Dismiss Screen Marker", "Dismiss a screen marker by ID", NotificationCategory.ADVANCED, DismissScreenMarker.class),
+    DISMISS_OBJECT_MARKER("Dismiss Object Marker", "Dismiss a object marker by ID", NotificationCategory.ADVANCED, DismissObjectMarker.class),
     REQUEST_FOCUS("Request Focus", "Requests focus on the window", NotificationCategory.ADVANCED, RequestFocus.class),
     NOTIFICATION_EVENT("Notification Event", "Fire a NotificationFired event so that other plugins may hook into it e.g. RL Tray Notifications", NotificationCategory.ADVANCED, NotificationEvent.class),
     ;


### PR DESCRIPTION
This is a simple change to remove the check for whether or not an overlay is sticky before dismissing it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications can now be dismissed by ID regardless of sticky status (previously ID-based dismissal only worked for sticky notifications).
  * Updated UI tooltip text to remove “sticky” wording for several dismissal actions so messaging matches the new behavior and clarifies dismissal semantics.
  * Tooltips now better reflect actual dismissal behavior for overlays and markers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamk33n3r/runelite-watchdog/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->