### PR TITLE
Add bank alerts

### DIFF
--- a/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
@@ -80,8 +80,10 @@ public class EventHandler {
     private final Map<Skill, Integer> previousSkillLevelTable = new EnumMap<>(Skill.class);
     private final Map<Skill, Integer> previousSkillXPTable = new EnumMap<>(Skill.class);
     private final Map<Integer, ItemComposition> itemCompositionCache = new ConcurrentHashMap<>();
-    private Map<Integer, InventoryItemData> previousItemsTable = new ConcurrentHashMap<>();
+    private Map<Integer, InventoryItemData> previousInventoryItemsTable = new ConcurrentHashMap<>();
+    private Map<Integer, InventoryItemData> previousBankItemsTable = new ConcurrentHashMap<>();
     private boolean hasInitializedInventory = false;
+    private boolean hasInitializedBank = false;
     private long previousInventorySlotCount = 0;
 //    private volatile long currentInventoryItemCount = 0;
 //    private volatile Map<Integer, InventoryItemData> currentItemsSnapshot = new ConcurrentHashMap<>();
@@ -196,8 +198,10 @@ public class EventHandler {
         if (state == GameState.LOGIN_SCREEN) {
             this.previousSkillLevelTable.clear();
             this.previousSkillXPTable.clear();
-            this.previousItemsTable.clear();
+            this.previousInventoryItemsTable.clear();
+            this.previousBankItemsTable.clear();
             this.hasInitializedInventory = false;
+            this.hasInitializedBank = false;
             this.previousInventorySlotCount = 0;
             this.cachedAccountType = -1;
         }
@@ -338,33 +342,41 @@ public class EventHandler {
                 .build());
         }
 
-        this.alertManager.getAllEnabledAlertsOfType(AdvancedAlert.class).forEach(adv -> {
-            adv.getGraph().getNodesOfType(Inventory.class).forEach(inv -> {
-                inv.setValue(currentItems);
-            });
-        });
+        int containerID = itemContainerChanged.getItemContainer().getId();
+        boolean isInventory = containerID == InventoryID.INV;
+        Map<Integer, InventoryItemData> previousItems = isInventory
+            ? this.previousInventoryItemsTable
+            : this.previousBankItemsTable;
+        boolean hasInitialized = isInventory ? this.hasInitializedInventory : this.hasInitializedBank;
 
-        // Skip firing alerts on the very first inventory event after login (no valid previous state yet).
-        if (this.hasInitializedInventory && !this.plugin.isInBannedArea()) {
+            this.alertManager.getAllEnabledAlertsOfType(AdvancedAlert.class).forEach(adv ->
+                adv.getGraph().getNodesOfType(Inventory.class).forEach(inv -> inv.setValue(currentItems)));
+
+        // Skip firing alerts on the first event for each container after login.
+        if (hasInitialized && !this.plugin.isInBannedArea()) {
             var itemMap = new InventoryItemData.InventoryItemDataMap(currentItems);
-            this.previousItemsTable.forEach((itemID, data) -> itemMap.getItems()
+            previousItems.forEach((itemID, data) -> itemMap.getItems()
                 .putIfAbsent(itemID, InventoryItemData.builder()
                 .itemComposition(data.getItemComposition())
                 .build()));
-            if (itemContainerChanged.getItemContainer().getId() == InventoryID.BANK) {
-                processBankChanges(itemContainerChanged, itemMap);
+            if (isInventory) {
+                this.processInventoryChanges(itemCount, itemMap, previousItems);
+            } else {
+                this.processBankChanges(itemMap, previousItems);
             }
-            if (itemContainerChanged.getItemContainer().getId() == InventoryID.INV) {
-                processInventoryChanges(itemContainerChanged, itemCount, itemMap);
-            }
-
         }
-        this.previousItemsTable = currentItems.getItems();
-        this.previousInventorySlotCount = itemCount;
-        this.hasInitializedInventory = true;
+
+        if (isInventory) {
+            this.previousInventoryItemsTable = currentItems.getItems();
+            this.previousInventorySlotCount = itemCount;
+            this.hasInitializedInventory = true;
+        } else {
+            this.previousBankItemsTable = currentItems.getItems();
+            this.hasInitializedBank = true;
+        }
     }
 
-    private void processInventoryChanges(ItemContainerChanged itemContainerChanged, long itemCount, InventoryItemData.InventoryItemDataMap itemMap) {
+    private void processInventoryChanges(long itemCount, InventoryItemData.InventoryItemDataMap itemMap, Map<Integer, InventoryItemData> previousItems) {
             this.alertManager.getAllEnabledAlertsOfType(InventoryAlert.class)
                     .forEach(inventoryAlert -> {
                         InventoryAlertType alertType = inventoryAlert.getInventoryAlertType();
@@ -385,7 +397,7 @@ public class EventHandler {
                                 break;
                             }
                             case ITEM: {
-                                Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems(), previousItems);
                                 matchedItems.ifPresent(matched -> {
                                     boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.currentQuantity, inventoryAlert.getItemQuantity());
                                     boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.previousQuantity, inventoryAlert.getItemQuantity());
@@ -395,7 +407,7 @@ public class EventHandler {
                                 break;
                             }
                             case ITEM_CHANGE: {
-                                Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems(), previousItems);
                                 matchedItems.ifPresent(matched -> {
                                     if (inventoryAlert.getQuantityComparator().compare(matched.currentQuantity - matched.previousQuantity, inventoryAlert.getItemQuantity()))
                                         this.fireAlert(inventoryAlert, matched.groups.toArray(new String[0]));
@@ -429,7 +441,7 @@ public class EventHandler {
                                         break;
                                     }
                                     case ITEM: {
-                                        Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                        Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems(), previousItems);
                                         if (matched.isPresent()) {
                                             boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity, inventoryAlert.getItemQuantity());
                                             boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.get().previousQuantity, inventoryAlert.getItemQuantity());
@@ -439,7 +451,7 @@ public class EventHandler {
                                         break;
                                     }
                                     case ITEM_CHANGE: {
-                                        Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                        Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems(), previousItems);
                                         if (matched.isPresent()) {
                                             if (inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity - matched.get().previousQuantity, inventoryAlert.getItemQuantity()))
                                                 groups = matched.get().groups.toArray(new String[0]);
@@ -452,13 +464,13 @@ public class EventHandler {
             );
     }
 
-    private void processBankChanges(ItemContainerChanged itemContainerChanged, InventoryItemData.InventoryItemDataMap itemMap) {
+    private void processBankChanges(InventoryItemData.InventoryItemDataMap itemMap, Map<Integer, InventoryItemData> previousItems) {
             this.alertManager.getAllEnabledAlertsOfType(BankAlert.class)
                     .forEach(bankAlert -> {
                         BankAlert.BankAlertType alertType = bankAlert.getBankAlertType();
                         switch (alertType) {
                             case ITEM: {
-                                Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems(), previousItems);
                                 matchedItems.ifPresent(matched -> {
                                     boolean condNow = bankAlert.getQuantityComparator().compare(matched.currentQuantity, bankAlert.getItemQuantity());
                                     boolean condPrev = bankAlert.getQuantityComparator().compare(matched.previousQuantity, bankAlert.getItemQuantity());
@@ -468,7 +480,7 @@ public class EventHandler {
                                 break;
                             }
                             case ITEM_CHANGE: {
-                                Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems(), previousItems);
                                 matchedItems.ifPresent(matched -> {
                                     if (bankAlert.getQuantityComparator().compare(matched.currentQuantity - matched.previousQuantity, bankAlert.getItemQuantity()))
                                         this.fireAlert(bankAlert, matched.groups.toArray(new String[0]));
@@ -487,7 +499,7 @@ public class EventHandler {
                                 String[] groups = null;
                                 switch (alertType) {
                                     case ITEM: {
-                                        Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                        Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems(), previousItems);
                                         if (matched.isPresent()) {
                                             boolean condNow = bankAlert.getQuantityComparator().compare(matched.get().currentQuantity, bankAlert.getItemQuantity());
                                             boolean condPrev = bankAlert.getQuantityComparator().compare(matched.get().previousQuantity, bankAlert.getItemQuantity());
@@ -497,7 +509,7 @@ public class EventHandler {
                                         break;
                                     }
                                     case ITEM_CHANGE: {
-                                        Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                        Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems(), previousItems);
                                         if (matched.isPresent()) {
                                             if (bankAlert.getQuantityComparator().compare(matched.get().currentQuantity - matched.get().previousQuantity, bankAlert.getItemQuantity()))
                                                 groups = matched.get().groups.toArray(new String[0]);
@@ -510,7 +522,7 @@ public class EventHandler {
             );
 }
 
-    private Optional<MatchedItem> getMatchedInventoryItems(InventoryAlert inventoryAlert, Map<Integer, InventoryItemData> allItems) {
+    private Optional<MatchedItem> getMatchedInventoryItems(InventoryAlert inventoryAlert, Map<Integer, InventoryItemData> allItems, Map<Integer, InventoryItemData> previousItems) {
         return allItems.entrySet().stream()
             .filter(itemData -> inventoryAlert.getInventoryMatchType() == InventoryAlert.InventoryMatchType.BOTH
                 || (inventoryAlert.getInventoryMatchType() == InventoryAlert.InventoryMatchType.NOTED && itemData.getValue().isNoted())
@@ -518,7 +530,7 @@ public class EventHandler {
             .map(itemData -> {
                 String[] groups = Util.matchPattern(inventoryAlert, itemData.getValue().getItemComposition().getName());
                 if (groups == null) return null;
-                var prevItem = this.previousItemsTable.get(itemData.getKey());
+                var prevItem = previousItems.get(itemData.getKey());
                 return new MatchedItem(
                     new ArrayList<>(List.of(groups)), // so that is mutable
                     prevItem == null ? 0 : prevItem.getQuantity(),
@@ -529,13 +541,13 @@ public class EventHandler {
             .reduce(EventHandler::itemQuantities);
     }
 
-    private Optional<MatchedItem> getMatchedBankItems(BankAlert bankAlert, Map<Integer, InventoryItemData> allItems) {
+    private Optional<MatchedItem> getMatchedBankItems(BankAlert bankAlert, Map<Integer, InventoryItemData> allItems, Map<Integer, InventoryItemData> previousItems) {
         return allItems.entrySet().stream()
                 .filter(itemData -> itemData.getValue().getItemComposition().getPlaceholderTemplateId() == -1)
                 .map(itemData -> {
                     String[] groups = Util.matchPattern(bankAlert, itemData.getValue().getItemComposition().getName());
                     if (groups == null) return null;
-                    var prevItem = this.previousItemsTable.get(itemData.getKey());
+                    var prevItem = previousItems.get(itemData.getKey());
                     return new MatchedItem(
                             new ArrayList<>(List.of(groups)), // so that is mutable
                             prevItem == null ? 0 : prevItem.getQuantity(),

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
@@ -351,156 +351,164 @@ public class EventHandler {
                 .putIfAbsent(itemID, InventoryItemData.builder()
                 .itemComposition(data.getItemComposition())
                 .build()));
-                    if (itemContainerChanged.getItemContainer().getId() == InventoryID.BANK) {
-
-                        this.alertManager.getAllEnabledAlertsOfType(BankAlert.class)
-                                .forEach(bankAlert -> {
-                                    BankAlert.BankAlertType alertType = bankAlert.getBankAlertType();
-                                    switch (alertType) {
-                                        case ITEM: {
-                                            Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems());
-                                            matchedItems.ifPresent(matched -> {
-                                                boolean condNow = bankAlert.getQuantityComparator().compare(matched.currentQuantity, bankAlert.getItemQuantity());
-                                                boolean condPrev = bankAlert.getQuantityComparator().compare(matched.previousQuantity, bankAlert.getItemQuantity());
-                                                if (condNow && (!bankAlert.isFireOnChange() || !condPrev))
-                                                    this.fireAlert(bankAlert, matched.groups.toArray(new String[0]));
-                                            });
-                                            break;
-                                        }
-                                        case ITEM_CHANGE: {
-                                            Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems());
-                                            matchedItems.ifPresent(matched -> {
-                                                if (bankAlert.getQuantityComparator().compare(matched.currentQuantity - matched.previousQuantity, bankAlert.getItemQuantity()))
-                                                    this.fireAlert(bankAlert, matched.groups.toArray(new String[0]));
-                                            });
-                                            break;
-                                        }
-                                    }
-                                });
-
-                        this.alertManager.getAllEnabledAlertsOfType(AdvancedAlert.class).forEach(adv ->
-                                adv.getGraph().getTriggerNodesOfType(BankAlert.class)
-                                        .filter(tn -> tn.getAlert().isEnabled())
-                                        .forEach(tn -> {
-                                            BankAlert bankAlert = (BankAlert) tn.getAlert();
-                                            BankAlert.BankAlertType alertType = bankAlert.getBankAlertType();
-                                            String[] groups = null;
-                                            switch (alertType) {
-                                                case ITEM: {
-                                                    Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems());
-                                                    if (matched.isPresent()) {
-                                                        boolean condNow = bankAlert.getQuantityComparator().compare(matched.get().currentQuantity, bankAlert.getItemQuantity());
-                                                        boolean condPrev = bankAlert.getQuantityComparator().compare(matched.get().previousQuantity, bankAlert.getItemQuantity());
-                                                        if (condNow && (!bankAlert.isFireOnChange() || !condPrev))
-                                                            groups = matched.get().groups.toArray(new String[0]);
-                                                    }
-                                                    break;
-                                                }
-                                                case ITEM_CHANGE: {
-                                                    Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems());
-                                                    if (matched.isPresent()) {
-                                                        if (bankAlert.getQuantityComparator().compare(matched.get().currentQuantity - matched.get().previousQuantity, bankAlert.getItemQuantity()))
-                                                            groups = matched.get().groups.toArray(new String[0]);
-                                                    }
-                                                    break;
-                                                }
-                                            }
-                                            if (groups != null) this.fireAdvancedAlertTriggerNode(adv, tn, groups);
-                                        })
-                        );
-                    }
-            if (itemContainerChanged.getItemContainer().getId() == InventoryID.INV) {
-                this.alertManager.getAllEnabledAlertsOfType(InventoryAlert.class)
-                        .forEach(inventoryAlert -> {
-                            InventoryAlertType alertType = inventoryAlert.getInventoryAlertType();
-                            switch (alertType) {
-                                case FULL:
-                                    if (itemCount == 28 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 28))
-                                        this.fireAlert(inventoryAlert, alertType.getName());
-                                    break;
-                                case EMPTY:
-                                    if (itemCount == 0 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 0))
-                                        this.fireAlert(inventoryAlert, alertType.getName());
-                                    break;
-                                case SLOTS: {
-                                    boolean slotNow = inventoryAlert.getQuantityComparator().compare((int) itemCount, inventoryAlert.getItemQuantity());
-                                    boolean slotPrev = inventoryAlert.getQuantityComparator().compare((int) this.previousInventorySlotCount, inventoryAlert.getItemQuantity());
-                                    if (slotNow && (!inventoryAlert.isFireOnChange() || !slotPrev))
-                                        this.fireAlert(inventoryAlert, alertType.getName());
-                                    break;
-                                }
-                                case ITEM: {
-                                    Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
-                                    matchedItems.ifPresent(matched -> {
-                                        boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.currentQuantity, inventoryAlert.getItemQuantity());
-                                        boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.previousQuantity, inventoryAlert.getItemQuantity());
-                                        if (condNow && (!inventoryAlert.isFireOnChange() || !condPrev))
-                                            this.fireAlert(inventoryAlert, matched.groups.toArray(new String[0]));
-                                    });
-                                    break;
-                                }
-                                case ITEM_CHANGE: {
-                                    Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
-                                    matchedItems.ifPresent(matched -> {
-                                        if (inventoryAlert.getQuantityComparator().compare(matched.currentQuantity - matched.previousQuantity, inventoryAlert.getItemQuantity()))
-                                            this.fireAlert(inventoryAlert, matched.groups.toArray(new String[0]));
-                                    });
-                                    break;
-                                }
-                            }
-                        });
-
-                this.alertManager.getAllEnabledAlertsOfType(AdvancedAlert.class).forEach(adv ->
-                        adv.getGraph().getTriggerNodesOfType(InventoryAlert.class)
-                                .filter(tn -> tn.getAlert().isEnabled())
-                                .forEach(tn -> {
-                                    InventoryAlert inventoryAlert = (InventoryAlert) tn.getAlert();
-                                    InventoryAlertType alertType = inventoryAlert.getInventoryAlertType();
-                                    String[] groups = null;
-                                    switch (alertType) {
-                                        case FULL:
-                                            if (itemCount == 28 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 28))
-                                                groups = new String[]{alertType.getName()};
-                                            break;
-                                        case EMPTY:
-                                            if (itemCount == 0 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 0))
-                                                groups = new String[]{alertType.getName()};
-                                            break;
-                                        case SLOTS: {
-                                            boolean slotNow = inventoryAlert.getQuantityComparator().compare((int) itemCount, inventoryAlert.getItemQuantity());
-                                            boolean slotPrev = inventoryAlert.getQuantityComparator().compare((int) this.previousInventorySlotCount, inventoryAlert.getItemQuantity());
-                                            if (slotNow && (!inventoryAlert.isFireOnChange() || !slotPrev))
-                                                groups = new String[]{alertType.getName()};
-                                            break;
-                                        }
-                                        case ITEM: {
-                                            Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
-                                            if (matched.isPresent()) {
-                                                boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity, inventoryAlert.getItemQuantity());
-                                                boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.get().previousQuantity, inventoryAlert.getItemQuantity());
-                                                if (condNow && (!inventoryAlert.isFireOnChange() || !condPrev))
-                                                    groups = matched.get().groups.toArray(new String[0]);
-                                            }
-                                            break;
-                                        }
-                                        case ITEM_CHANGE: {
-                                            Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
-                                            if (matched.isPresent()) {
-                                                if (inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity - matched.get().previousQuantity, inventoryAlert.getItemQuantity()))
-                                                    groups = matched.get().groups.toArray(new String[0]);
-                                            }
-                                            break;
-                                        }
-                                    }
-                                    if (groups != null) this.fireAdvancedAlertTriggerNode(adv, tn, groups);
-                                })
-                );
+            if (itemContainerChanged.getItemContainer().getId() == InventoryID.BANK) {
+                processBankChanges(itemContainerChanged, itemMap);
             }
+            if (itemContainerChanged.getItemContainer().getId() == InventoryID.INV) {
+                processInventoryChanges(itemContainerChanged, itemCount, itemMap);
+            }
+
         }
         this.previousItemsTable = currentItems.getItems();
         this.previousInventorySlotCount = itemCount;
         this.hasInitializedInventory = true;
     }
+
+    private void processInventoryChanges(ItemContainerChanged itemContainerChanged, long itemCount, InventoryItemData.InventoryItemDataMap itemMap) {
+            this.alertManager.getAllEnabledAlertsOfType(InventoryAlert.class)
+                    .forEach(inventoryAlert -> {
+                        InventoryAlertType alertType = inventoryAlert.getInventoryAlertType();
+                        switch (alertType) {
+                            case FULL:
+                                if (itemCount == 28 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 28))
+                                    this.fireAlert(inventoryAlert, alertType.getName());
+                                break;
+                            case EMPTY:
+                                if (itemCount == 0 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 0))
+                                    this.fireAlert(inventoryAlert, alertType.getName());
+                                break;
+                            case SLOTS: {
+                                boolean slotNow = inventoryAlert.getQuantityComparator().compare((int) itemCount, inventoryAlert.getItemQuantity());
+                                boolean slotPrev = inventoryAlert.getQuantityComparator().compare((int) this.previousInventorySlotCount, inventoryAlert.getItemQuantity());
+                                if (slotNow && (!inventoryAlert.isFireOnChange() || !slotPrev))
+                                    this.fireAlert(inventoryAlert, alertType.getName());
+                                break;
+                            }
+                            case ITEM: {
+                                Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                matchedItems.ifPresent(matched -> {
+                                    boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.currentQuantity, inventoryAlert.getItemQuantity());
+                                    boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.previousQuantity, inventoryAlert.getItemQuantity());
+                                    if (condNow && (!inventoryAlert.isFireOnChange() || !condPrev))
+                                        this.fireAlert(inventoryAlert, matched.groups.toArray(new String[0]));
+                                });
+                                break;
+                            }
+                            case ITEM_CHANGE: {
+                                Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                matchedItems.ifPresent(matched -> {
+                                    if (inventoryAlert.getQuantityComparator().compare(matched.currentQuantity - matched.previousQuantity, inventoryAlert.getItemQuantity()))
+                                        this.fireAlert(inventoryAlert, matched.groups.toArray(new String[0]));
+                                });
+                                break;
+                            }
+                        }
+                    });
+
+            this.alertManager.getAllEnabledAlertsOfType(AdvancedAlert.class).forEach(adv ->
+                    adv.getGraph().getTriggerNodesOfType(InventoryAlert.class)
+                            .filter(tn -> tn.getAlert().isEnabled())
+                            .forEach(tn -> {
+                                InventoryAlert inventoryAlert = (InventoryAlert) tn.getAlert();
+                                InventoryAlertType alertType = inventoryAlert.getInventoryAlertType();
+                                String[] groups = null;
+                                switch (alertType) {
+                                    case FULL:
+                                        if (itemCount == 28 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 28))
+                                            groups = new String[]{alertType.getName()};
+                                        break;
+                                    case EMPTY:
+                                        if (itemCount == 0 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 0))
+                                            groups = new String[]{alertType.getName()};
+                                        break;
+                                    case SLOTS: {
+                                        boolean slotNow = inventoryAlert.getQuantityComparator().compare((int) itemCount, inventoryAlert.getItemQuantity());
+                                        boolean slotPrev = inventoryAlert.getQuantityComparator().compare((int) this.previousInventorySlotCount, inventoryAlert.getItemQuantity());
+                                        if (slotNow && (!inventoryAlert.isFireOnChange() || !slotPrev))
+                                            groups = new String[]{alertType.getName()};
+                                        break;
+                                    }
+                                    case ITEM: {
+                                        Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                        if (matched.isPresent()) {
+                                            boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity, inventoryAlert.getItemQuantity());
+                                            boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.get().previousQuantity, inventoryAlert.getItemQuantity());
+                                            if (condNow && (!inventoryAlert.isFireOnChange() || !condPrev))
+                                                groups = matched.get().groups.toArray(new String[0]);
+                                        }
+                                        break;
+                                    }
+                                    case ITEM_CHANGE: {
+                                        Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                        if (matched.isPresent()) {
+                                            if (inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity - matched.get().previousQuantity, inventoryAlert.getItemQuantity()))
+                                                groups = matched.get().groups.toArray(new String[0]);
+                                        }
+                                        break;
+                                    }
+                                }
+                                if (groups != null) this.fireAdvancedAlertTriggerNode(adv, tn, groups);
+                            })
+            );
+    }
+
+    private void processBankChanges(ItemContainerChanged itemContainerChanged, InventoryItemData.InventoryItemDataMap itemMap) {
+            this.alertManager.getAllEnabledAlertsOfType(BankAlert.class)
+                    .forEach(bankAlert -> {
+                        BankAlert.BankAlertType alertType = bankAlert.getBankAlertType();
+                        switch (alertType) {
+                            case ITEM: {
+                                Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                matchedItems.ifPresent(matched -> {
+                                    boolean condNow = bankAlert.getQuantityComparator().compare(matched.currentQuantity, bankAlert.getItemQuantity());
+                                    boolean condPrev = bankAlert.getQuantityComparator().compare(matched.previousQuantity, bankAlert.getItemQuantity());
+                                    if (condNow && (!bankAlert.isFireOnChange() || !condPrev))
+                                        this.fireAlert(bankAlert, matched.groups.toArray(new String[0]));
+                                });
+                                break;
+                            }
+                            case ITEM_CHANGE: {
+                                Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                matchedItems.ifPresent(matched -> {
+                                    if (bankAlert.getQuantityComparator().compare(matched.currentQuantity - matched.previousQuantity, bankAlert.getItemQuantity()))
+                                        this.fireAlert(bankAlert, matched.groups.toArray(new String[0]));
+                                });
+                                break;
+                            }
+                        }
+                    });
+
+            this.alertManager.getAllEnabledAlertsOfType(AdvancedAlert.class).forEach(adv ->
+                    adv.getGraph().getTriggerNodesOfType(BankAlert.class)
+                            .filter(tn -> tn.getAlert().isEnabled())
+                            .forEach(tn -> {
+                                BankAlert bankAlert = (BankAlert) tn.getAlert();
+                                BankAlert.BankAlertType alertType = bankAlert.getBankAlertType();
+                                String[] groups = null;
+                                switch (alertType) {
+                                    case ITEM: {
+                                        Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                        if (matched.isPresent()) {
+                                            boolean condNow = bankAlert.getQuantityComparator().compare(matched.get().currentQuantity, bankAlert.getItemQuantity());
+                                            boolean condPrev = bankAlert.getQuantityComparator().compare(matched.get().previousQuantity, bankAlert.getItemQuantity());
+                                            if (condNow && (!bankAlert.isFireOnChange() || !condPrev))
+                                                groups = matched.get().groups.toArray(new String[0]);
+                                        }
+                                        break;
+                                    }
+                                    case ITEM_CHANGE: {
+                                        Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                        if (matched.isPresent()) {
+                                            if (bankAlert.getQuantityComparator().compare(matched.get().currentQuantity - matched.get().previousQuantity, bankAlert.getItemQuantity()))
+                                                groups = matched.get().groups.toArray(new String[0]);
+                                        }
+                                        break;
+                                    }
+                                }
+                                if (groups != null) this.fireAdvancedAlertTriggerNode(adv, tn, groups);
+                            })
+            );
+}
 
     private Optional<MatchedItem> getMatchedInventoryItems(InventoryAlert inventoryAlert, Map<Integer, InventoryItemData> allItems) {
         return allItems.entrySet().stream()

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
@@ -314,14 +314,10 @@ public class EventHandler {
     //region Inventory
     @Subscribe
     void onItemContainerChanged(ItemContainerChanged itemContainerChanged) {
-        // Ignore everything but inventory
+        // Ignore everything but inventory and bank
         if (itemContainerChanged.getItemContainer().getId() != InventoryID.INV &&
                 itemContainerChanged.getItemContainer().getId() != InventoryID.BANK)
             return;
-        /*
-        when it's the inventory container, do the inventory stuff
-        when it's bank, do bank
-         */
         Item[] items = itemContainerChanged.getItemContainer().getItems();
         long itemCount = Arrays.stream(items).filter(item -> item.getId() > -1).count();
         InventoryItemData[] slots = new InventoryItemData[items.length];

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
@@ -26,6 +26,7 @@ import net.runelite.client.util.Text;
 
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -517,14 +518,7 @@ public class EventHandler {
                 );
             })
             .filter(Objects::nonNull)
-            .reduce((acc, b) -> {
-                acc.groups = IntStream.range(0, Math.min(acc.groups.size(), b.groups.size()))
-                    .mapToObj(i -> acc.groups.get(i) + ", " + b.groups.get(i))
-                    .collect(Collectors.toList());
-                acc.previousQuantity = acc.previousQuantity + b.previousQuantity;
-                acc.currentQuantity = acc.currentQuantity + b.currentQuantity;
-                return acc;
-            });
+            .reduce(EventHandler::itemQuantities);
     }
 
     private Optional<MatchedItem> getMatchedBankItems(BankAlert bankAlert, Map<Integer, InventoryItemData> allItems) {
@@ -541,14 +535,17 @@ public class EventHandler {
                     );
                 })
                 .filter(Objects::nonNull)
-                .reduce((acc, b) -> {
-                    acc.groups = IntStream.range(0, Math.min(acc.groups.size(), b.groups.size()))
-                            .mapToObj(i -> acc.groups.get(i) + ", " + b.groups.get(i))
-                            .collect(Collectors.toList());
-                    acc.previousQuantity = acc.previousQuantity + b.previousQuantity;
-                    acc.currentQuantity = acc.currentQuantity + b.currentQuantity;
-                    return acc;
-                });
+                .reduce(EventHandler::itemQuantities);
+    }
+
+    @Nonnull
+    private static MatchedItem itemQuantities(MatchedItem acc, MatchedItem b) {
+        acc.groups = IntStream.range(0, Math.min(acc.groups.size(), b.groups.size()))
+                .mapToObj(i -> acc.groups.get(i) + ", " + b.groups.get(i))
+                .collect(Collectors.toList());
+        acc.previousQuantity = acc.previousQuantity + b.previousQuantity;
+        acc.currentQuantity = acc.currentQuantity + b.currentQuantity;
+        return acc;
     }
     //endregion
 

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/EventHandler.java
@@ -315,8 +315,13 @@ public class EventHandler {
     @Subscribe
     void onItemContainerChanged(ItemContainerChanged itemContainerChanged) {
         // Ignore everything but inventory
-        if (itemContainerChanged.getItemContainer().getId() != InventoryID.INV)
+        if (itemContainerChanged.getItemContainer().getId() != InventoryID.INV &&
+                itemContainerChanged.getItemContainer().getId() != InventoryID.BANK)
             return;
+        /*
+        when it's the inventory container, do the inventory stuff
+        when it's bank, do bank
+         */
         Item[] items = itemContainerChanged.getItemContainer().getItems();
         long itemCount = Arrays.stream(items).filter(item -> item.getId() > -1).count();
         InventoryItemData[] slots = new InventoryItemData[items.length];
@@ -349,98 +354,158 @@ public class EventHandler {
                 .putIfAbsent(itemID, InventoryItemData.builder()
                 .itemComposition(data.getItemComposition())
                 .build()));
-            this.alertManager.getAllEnabledAlertsOfType(InventoryAlert.class)
-                .forEach(inventoryAlert -> {
-                    InventoryAlertType alertType = inventoryAlert.getInventoryAlertType();
-                    switch (alertType) {
-                        case FULL:
-                            if (itemCount == 28 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 28))
-                                this.fireAlert(inventoryAlert, alertType.getName());
-                            break;
-                        case EMPTY:
-                            if (itemCount == 0 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 0))
-                                this.fireAlert(inventoryAlert, alertType.getName());
-                            break;
-                        case SLOTS: {
-                            boolean slotNow = inventoryAlert.getQuantityComparator().compare((int) itemCount, inventoryAlert.getItemQuantity());
-                            boolean slotPrev = inventoryAlert.getQuantityComparator().compare((int) this.previousInventorySlotCount, inventoryAlert.getItemQuantity());
-                            if (slotNow && (!inventoryAlert.isFireOnChange() || !slotPrev))
-                                this.fireAlert(inventoryAlert, alertType.getName());
-                            break;
-                        }
-                        case ITEM: {
-                            Optional<MatchedItem> matchedItems = this.getMatchedItems(inventoryAlert, itemMap.getItems());
-                            matchedItems.ifPresent(matched -> {
-                                boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.currentQuantity, inventoryAlert.getItemQuantity());
-                                boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.previousQuantity, inventoryAlert.getItemQuantity());
-                                if (condNow && (!inventoryAlert.isFireOnChange() || !condPrev))
-                                    this.fireAlert(inventoryAlert, matched.groups.toArray(new String[0]));
-                            });
-                            break;
-                        }
-                        case ITEM_CHANGE: {
-                            Optional<MatchedItem> matchedItems = this.getMatchedItems(inventoryAlert, itemMap.getItems());
-                            matchedItems.ifPresent(matched -> {
-                                if (inventoryAlert.getQuantityComparator().compare(matched.currentQuantity - matched.previousQuantity, inventoryAlert.getItemQuantity()))
-                                    this.fireAlert(inventoryAlert, matched.groups.toArray(new String[0]));
-                            });
-                            break;
-                        }
-                    }
-                });
+                    if (itemContainerChanged.getItemContainer().getId() == InventoryID.BANK) {
 
-            this.alertManager.getAllEnabledAlertsOfType(AdvancedAlert.class).forEach(adv ->
-                adv.getGraph().getTriggerNodesOfType(InventoryAlert.class)
-                    .filter(tn -> tn.getAlert().isEnabled())
-                    .forEach(tn -> {
-                        InventoryAlert inventoryAlert = (InventoryAlert) tn.getAlert();
-                        InventoryAlertType alertType = inventoryAlert.getInventoryAlertType();
-                        String[] groups = null;
-                        switch (alertType) {
-                            case FULL:
-                                if (itemCount == 28 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 28))
-                                    groups = new String[]{ alertType.getName() };
-                                break;
-                            case EMPTY:
-                                if (itemCount == 0 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 0))
-                                    groups = new String[]{ alertType.getName() };
-                                break;
-                            case SLOTS: {
-                                boolean slotNow = inventoryAlert.getQuantityComparator().compare((int) itemCount, inventoryAlert.getItemQuantity());
-                                boolean slotPrev = inventoryAlert.getQuantityComparator().compare((int) this.previousInventorySlotCount, inventoryAlert.getItemQuantity());
-                                if (slotNow && (!inventoryAlert.isFireOnChange() || !slotPrev))
-                                    groups = new String[]{ alertType.getName() };
-                                break;
-                            }
-                            case ITEM: {
-                                Optional<MatchedItem> matched = this.getMatchedItems(inventoryAlert, itemMap.getItems());
-                                if (matched.isPresent()) {
-                                    boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity, inventoryAlert.getItemQuantity());
-                                    boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.get().previousQuantity, inventoryAlert.getItemQuantity());
-                                    if (condNow && (!inventoryAlert.isFireOnChange() || !condPrev))
-                                        groups = matched.get().groups.toArray(new String[0]);
+                        this.alertManager.getAllEnabledAlertsOfType(BankAlert.class)
+                                .forEach(bankAlert -> {
+                                    BankAlert.BankAlertType alertType = bankAlert.getBankAlertType();
+                                    switch (alertType) {
+                                        case ITEM: {
+                                            Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                            matchedItems.ifPresent(matched -> {
+                                                boolean condNow = bankAlert.getQuantityComparator().compare(matched.currentQuantity, bankAlert.getItemQuantity());
+                                                boolean condPrev = bankAlert.getQuantityComparator().compare(matched.previousQuantity, bankAlert.getItemQuantity());
+                                                if (condNow && (!bankAlert.isFireOnChange() || !condPrev))
+                                                    this.fireAlert(bankAlert, matched.groups.toArray(new String[0]));
+                                            });
+                                            break;
+                                        }
+                                        case ITEM_CHANGE: {
+                                            Optional<MatchedItem> matchedItems = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                            matchedItems.ifPresent(matched -> {
+                                                if (bankAlert.getQuantityComparator().compare(matched.currentQuantity - matched.previousQuantity, bankAlert.getItemQuantity()))
+                                                    this.fireAlert(bankAlert, matched.groups.toArray(new String[0]));
+                                            });
+                                            break;
+                                        }
+                                    }
+                                });
+
+                        this.alertManager.getAllEnabledAlertsOfType(AdvancedAlert.class).forEach(adv ->
+                                adv.getGraph().getTriggerNodesOfType(BankAlert.class)
+                                        .filter(tn -> tn.getAlert().isEnabled())
+                                        .forEach(tn -> {
+                                            BankAlert bankAlert = (BankAlert) tn.getAlert();
+                                            BankAlert.BankAlertType alertType = bankAlert.getBankAlertType();
+                                            String[] groups = null;
+                                            switch (alertType) {
+                                                case ITEM: {
+                                                    Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                                    if (matched.isPresent()) {
+                                                        boolean condNow = bankAlert.getQuantityComparator().compare(matched.get().currentQuantity, bankAlert.getItemQuantity());
+                                                        boolean condPrev = bankAlert.getQuantityComparator().compare(matched.get().previousQuantity, bankAlert.getItemQuantity());
+                                                        if (condNow && (!bankAlert.isFireOnChange() || !condPrev))
+                                                            groups = matched.get().groups.toArray(new String[0]);
+                                                    }
+                                                    break;
+                                                }
+                                                case ITEM_CHANGE: {
+                                                    Optional<MatchedItem> matched = this.getMatchedBankItems(bankAlert, itemMap.getItems());
+                                                    if (matched.isPresent()) {
+                                                        if (bankAlert.getQuantityComparator().compare(matched.get().currentQuantity - matched.get().previousQuantity, bankAlert.getItemQuantity()))
+                                                            groups = matched.get().groups.toArray(new String[0]);
+                                                    }
+                                                    break;
+                                                }
+                                            }
+                                            if (groups != null) this.fireAdvancedAlertTriggerNode(adv, tn, groups);
+                                        })
+                        );
+                    }
+            if (itemContainerChanged.getItemContainer().getId() == InventoryID.INV) {
+                this.alertManager.getAllEnabledAlertsOfType(InventoryAlert.class)
+                        .forEach(inventoryAlert -> {
+                            InventoryAlertType alertType = inventoryAlert.getInventoryAlertType();
+                            switch (alertType) {
+                                case FULL:
+                                    if (itemCount == 28 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 28))
+                                        this.fireAlert(inventoryAlert, alertType.getName());
+                                    break;
+                                case EMPTY:
+                                    if (itemCount == 0 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 0))
+                                        this.fireAlert(inventoryAlert, alertType.getName());
+                                    break;
+                                case SLOTS: {
+                                    boolean slotNow = inventoryAlert.getQuantityComparator().compare((int) itemCount, inventoryAlert.getItemQuantity());
+                                    boolean slotPrev = inventoryAlert.getQuantityComparator().compare((int) this.previousInventorySlotCount, inventoryAlert.getItemQuantity());
+                                    if (slotNow && (!inventoryAlert.isFireOnChange() || !slotPrev))
+                                        this.fireAlert(inventoryAlert, alertType.getName());
+                                    break;
                                 }
-                                break;
-                            }
-                            case ITEM_CHANGE: {
-                                Optional<MatchedItem> matched = this.getMatchedItems(inventoryAlert, itemMap.getItems());
-                                if (matched.isPresent()) {
-                                    if (inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity - matched.get().previousQuantity, inventoryAlert.getItemQuantity()))
-                                        groups = matched.get().groups.toArray(new String[0]);
+                                case ITEM: {
+                                    Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                    matchedItems.ifPresent(matched -> {
+                                        boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.currentQuantity, inventoryAlert.getItemQuantity());
+                                        boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.previousQuantity, inventoryAlert.getItemQuantity());
+                                        if (condNow && (!inventoryAlert.isFireOnChange() || !condPrev))
+                                            this.fireAlert(inventoryAlert, matched.groups.toArray(new String[0]));
+                                    });
+                                    break;
                                 }
-                                break;
+                                case ITEM_CHANGE: {
+                                    Optional<MatchedItem> matchedItems = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                    matchedItems.ifPresent(matched -> {
+                                        if (inventoryAlert.getQuantityComparator().compare(matched.currentQuantity - matched.previousQuantity, inventoryAlert.getItemQuantity()))
+                                            this.fireAlert(inventoryAlert, matched.groups.toArray(new String[0]));
+                                    });
+                                    break;
+                                }
                             }
-                        }
-                        if (groups != null) this.fireAdvancedAlertTriggerNode(adv, tn, groups);
-                    })
-            );
+                        });
+
+                this.alertManager.getAllEnabledAlertsOfType(AdvancedAlert.class).forEach(adv ->
+                        adv.getGraph().getTriggerNodesOfType(InventoryAlert.class)
+                                .filter(tn -> tn.getAlert().isEnabled())
+                                .forEach(tn -> {
+                                    InventoryAlert inventoryAlert = (InventoryAlert) tn.getAlert();
+                                    InventoryAlertType alertType = inventoryAlert.getInventoryAlertType();
+                                    String[] groups = null;
+                                    switch (alertType) {
+                                        case FULL:
+                                            if (itemCount == 28 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 28))
+                                                groups = new String[]{alertType.getName()};
+                                            break;
+                                        case EMPTY:
+                                            if (itemCount == 0 && (!inventoryAlert.isFireOnChange() || this.previousInventorySlotCount != 0))
+                                                groups = new String[]{alertType.getName()};
+                                            break;
+                                        case SLOTS: {
+                                            boolean slotNow = inventoryAlert.getQuantityComparator().compare((int) itemCount, inventoryAlert.getItemQuantity());
+                                            boolean slotPrev = inventoryAlert.getQuantityComparator().compare((int) this.previousInventorySlotCount, inventoryAlert.getItemQuantity());
+                                            if (slotNow && (!inventoryAlert.isFireOnChange() || !slotPrev))
+                                                groups = new String[]{alertType.getName()};
+                                            break;
+                                        }
+                                        case ITEM: {
+                                            Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                            if (matched.isPresent()) {
+                                                boolean condNow = inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity, inventoryAlert.getItemQuantity());
+                                                boolean condPrev = inventoryAlert.getQuantityComparator().compare(matched.get().previousQuantity, inventoryAlert.getItemQuantity());
+                                                if (condNow && (!inventoryAlert.isFireOnChange() || !condPrev))
+                                                    groups = matched.get().groups.toArray(new String[0]);
+                                            }
+                                            break;
+                                        }
+                                        case ITEM_CHANGE: {
+                                            Optional<MatchedItem> matched = this.getMatchedInventoryItems(inventoryAlert, itemMap.getItems());
+                                            if (matched.isPresent()) {
+                                                if (inventoryAlert.getQuantityComparator().compare(matched.get().currentQuantity - matched.get().previousQuantity, inventoryAlert.getItemQuantity()))
+                                                    groups = matched.get().groups.toArray(new String[0]);
+                                            }
+                                            break;
+                                        }
+                                    }
+                                    if (groups != null) this.fireAdvancedAlertTriggerNode(adv, tn, groups);
+                                })
+                );
+            }
         }
         this.previousItemsTable = currentItems.getItems();
         this.previousInventorySlotCount = itemCount;
         this.hasInitializedInventory = true;
     }
 
-    private Optional<MatchedItem> getMatchedItems(InventoryAlert inventoryAlert, Map<Integer, InventoryItemData> allItems) {
+    private Optional<MatchedItem> getMatchedInventoryItems(InventoryAlert inventoryAlert, Map<Integer, InventoryItemData> allItems) {
         return allItems.entrySet().stream()
             .filter(itemData -> inventoryAlert.getInventoryMatchType() == InventoryAlert.InventoryMatchType.BOTH
                 || (inventoryAlert.getInventoryMatchType() == InventoryAlert.InventoryMatchType.NOTED && itemData.getValue().isNoted())
@@ -464,6 +529,30 @@ public class EventHandler {
                 acc.currentQuantity = acc.currentQuantity + b.currentQuantity;
                 return acc;
             });
+    }
+
+    private Optional<MatchedItem> getMatchedBankItems(BankAlert bankAlert, Map<Integer, InventoryItemData> allItems) {
+        return allItems.entrySet().stream()
+                .filter(itemData -> itemData.getValue().getItemComposition().getPlaceholderTemplateId() == -1)
+                .map(itemData -> {
+                    String[] groups = Util.matchPattern(bankAlert, itemData.getValue().getItemComposition().getName());
+                    if (groups == null) return null;
+                    var prevItem = this.previousItemsTable.get(itemData.getKey());
+                    return new MatchedItem(
+                            new ArrayList<>(List.of(groups)), // so that is mutable
+                            prevItem == null ? 0 : prevItem.getQuantity(),
+                            itemData.getValue().getQuantity()
+                    );
+                })
+                .filter(Objects::nonNull)
+                .reduce((acc, b) -> {
+                    acc.groups = IntStream.range(0, Math.min(acc.groups.size(), b.groups.size()))
+                            .mapToObj(i -> acc.groups.get(i) + ", " + b.groups.get(i))
+                            .collect(Collectors.toList());
+                    acc.previousQuantity = acc.previousQuantity + b.previousQuantity;
+                    acc.currentQuantity = acc.currentQuantity + b.currentQuantity;
+                    return acc;
+                });
     }
     //endregion
 

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/TriggerType.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/TriggerType.java
@@ -19,7 +19,7 @@ public enum TriggerType implements Displayable {
     SPAWNED_OBJECT("Spawned Object", "When an object, player, or npc spawns or despawns", SpawnedAlert.class),
     INVENTORY("Inventory", "When your inventory is full, empty, or contains certain items", InventoryAlert.class),
     LOCATION("Location", "Triggers when you near a set location", LocationAlert.class),
-    BANK("Bank", "When your bank is full, empty, or contains certain items", BankAlert.class),
+    BANK("Bank", "When your bank contains certain items", BankAlert.class),
     // Keep this last so that people maybe won't try to use it over the chat one
     NOTIFICATION_FIRED("Notification Fired", "When other plugins fire notifications", NotificationFiredAlert.class),
     ADVANCED_ALERT("Advanced Alert", "Visual node graph based alert", AdvancedAlert.class),

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/TriggerType.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/TriggerType.java
@@ -18,8 +18,8 @@ public enum TriggerType implements Displayable {
     SOUND_FIRED("Sound Fired", "When a sound effect plays", SoundFiredAlert.class),
     SPAWNED_OBJECT("Spawned Object", "When an object, player, or npc spawns or despawns", SpawnedAlert.class),
     INVENTORY("Inventory", "When your inventory is full, empty, or contains certain items", InventoryAlert.class),
-    LOCATION("Location", "Triggers when you near a set location", LocationAlert.class),
     BANK("Bank", "When your bank contains certain items", BankAlert.class),
+    LOCATION("Location", "Triggers when you near a set location", LocationAlert.class),
     // Keep this last so that people maybe won't try to use it over the chat one
     NOTIFICATION_FIRED("Notification Fired", "When other plugins fire notifications", NotificationFiredAlert.class),
     ADVANCED_ALERT("Advanced Alert", "Visual node graph based alert", AdvancedAlert.class),

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/TriggerType.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/TriggerType.java
@@ -19,6 +19,7 @@ public enum TriggerType implements Displayable {
     SPAWNED_OBJECT("Spawned Object", "When an object, player, or npc spawns or despawns", SpawnedAlert.class),
     INVENTORY("Inventory", "When your inventory is full, empty, or contains certain items", InventoryAlert.class),
     LOCATION("Location", "Triggers when you near a set location", LocationAlert.class),
+    BANK("Bank", "When your bank is full, empty, or contains certain items", BankAlert.class),
     // Keep this last so that people maybe won't try to use it over the chat one
     NOTIFICATION_FIRED("Notification Fired", "When other plugins fire notifications", NotificationFiredAlert.class),
     ADVANCED_ALERT("Advanced Alert", "Visual node graph based alert", AdvancedAlert.class),

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/WatchdogPanel.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/WatchdogPanel.java
@@ -244,6 +244,8 @@ public class WatchdogPanel extends PluginPanel {
             return new AlertPanel<>(this, new SpawnedAlertPanel((SpawnedAlert) alert, onChange));
         if (alert instanceof InventoryAlert)
             return new AlertPanel<>(this, new InventoryAlertPanel((InventoryAlert) alert, onChange));
+        if (alert instanceof BankAlert)
+            return new AlertPanel<>(this, new BankAlertPanel((BankAlert) alert, onChange));
         if (alert instanceof AlertGroup)
             return new AlertPanel<>(this, new AlertGroupPanel((AlertGroup) alert, this, onChange));
         if (alert instanceof LocationAlert)

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/alerts/BankAlert.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/alerts/BankAlert.java
@@ -1,0 +1,50 @@
+package com.adamk33n3r.runelite.watchdog.alerts;
+
+import com.adamk33n3r.runelite.watchdog.Displayable;
+import com.adamk33n3r.runelite.watchdog.ui.ComparableNumber;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+public class BankAlert extends Alert implements RegexMatcher {
+    private String itemName = "";
+    @Accessors(chain = false)
+    private boolean isRegexEnabled = false;
+    private int itemQuantity = 1;
+    private ComparableNumber.Comparator quantityComparator = ComparableNumber.Comparator.GREATER_THAN_OR_EQUALS;
+    private boolean fireOnChange = false;
+    private BankAlert.BankAlertType bankAlertType = BankAlertType.ITEM;
+
+    @Override
+    public String getPattern() {
+        return this.itemName;
+    }
+
+    @Override
+    public void setPattern(String pattern) {
+        this.itemName = pattern;
+    }
+
+    public BankAlert() {
+        super("New Bank Alert");
+    }
+
+    public BankAlert(String name) {
+        super(name);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public enum BankAlertType implements Displayable {
+        ITEM("Item Count", "Triggers when an item hits a certain count"),
+        ITEM_CHANGE("Item Change", "Triggers when an item is added or removed")
+        ;
+
+        private final String name;
+        private final String tooltip;
+    }
+}

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/serialization/WatchdogGsonFactory.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/serialization/WatchdogGsonFactory.java
@@ -55,6 +55,7 @@ public class WatchdogGsonFactory {
             .registerSubtype(SoundFiredAlert.class)
             .registerSubtype(SpawnedAlert.class)
             .registerSubtype(InventoryAlert.class)
+                .registerSubtype(BankAlert.class)
             .registerSubtype(AlertGroup.class)
             .registerSubtype(LocationAlert.class)
             .registerSubtype(AdvancedAlert.class);

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/serialization/WatchdogGsonFactory.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/serialization/WatchdogGsonFactory.java
@@ -55,7 +55,7 @@ public class WatchdogGsonFactory {
             .registerSubtype(SoundFiredAlert.class)
             .registerSubtype(SpawnedAlert.class)
             .registerSubtype(InventoryAlert.class)
-                .registerSubtype(BankAlert.class)
+            .registerSubtype(BankAlert.class)
             .registerSubtype(AlertGroup.class)
             .registerSubtype(LocationAlert.class)
             .registerSubtype(AdvancedAlert.class);

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/ui/alerts/BankAlertPanel.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/ui/alerts/BankAlertPanel.java
@@ -23,7 +23,7 @@ public class BankAlertPanel extends AlertContentPanel<BankAlert> {
                 this.rebuild();
             })
             .addIf(
-                b -> b.addCheckbox("Don't fire when opening bank", "Only fire when the condition first becomes true, not on every tick while it remains true", this.alert.isFireOnChange(), this.alert::setFireOnChange),
+                b -> b.addCheckbox("Don't fire when opening bank", "Only fire when the condition first becomes true when removing or adding to the bank", this.alert.isFireOnChange(), this.alert::setFireOnChange),
                 () -> alertType != BankAlert.BankAlertType.ITEM_CHANGE
             )
             .addIf(

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/ui/alerts/BankAlertPanel.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/ui/alerts/BankAlertPanel.java
@@ -1,0 +1,39 @@
+package com.adamk33n3r.runelite.watchdog.ui.alerts;
+
+import com.adamk33n3r.runelite.watchdog.alerts.BankAlert;
+import com.adamk33n3r.runelite.watchdog.alerts.InventoryAlert;
+import com.adamk33n3r.runelite.watchdog.ui.ComparableNumber;
+import com.adamk33n3r.runelite.watchdog.ui.panels.AlertContentPanel;
+import com.adamk33n3r.runelite.watchdog.ui.panels.PanelUtils;
+
+public class BankAlertPanel extends AlertContentPanel<BankAlert> {
+
+    public BankAlertPanel(BankAlert alert, Runnable onChange) {
+        super(alert, onChange);
+        this.init();
+    }
+
+    @Override
+    public void buildTypeContent() {
+        BankAlert.BankAlertType alertType = this.alert.getBankAlertType();
+        boolean isItemChange = alertType == BankAlert.BankAlertType.ITEM_CHANGE;
+        this.addSelect("Type", "Type of bank alert", BankAlert.BankAlertType.class, alertType,
+            val -> {
+                this.alert.setBankAlertType(val);
+                this.rebuild();
+            })
+            .addIf(
+                b -> b.addCheckbox("Don't fire when opening bank", "Only fire when the condition first becomes true, not on every tick while it remains true", this.alert.isFireOnChange(), this.alert::setFireOnChange),
+                () -> alertType != BankAlert.BankAlertType.ITEM_CHANGE
+            )
+            .addIf(
+                b -> b
+                    .addRegexMatcher(this.alert, "Enter the name of the item to trigger on...", "The name to trigger on. Supports glob (*)")
+                    .addSubPanelControl(PanelUtils.createLabeledComponent(
+                        isItemChange ? "Change" : "Quantity",
+                        isItemChange ? "The quantity change of the item (in one tick) to trigger on. Negative for loss, positive for gain, 0 for no change" : "The quantity of item to trigger on",
+                        new ComparableNumber(this.alert.getItemQuantity(), this.alert::setItemQuantity, isItemChange ? Integer.MIN_VALUE : 0, Integer.MAX_VALUE, 1, this.alert.getQuantityComparator(), this.alert::setQuantityComparator))),
+                () -> alertType == BankAlert.BankAlertType.ITEM || isItemChange
+            );
+    }
+}

--- a/src/main/java/com/adamk33n3r/runelite/watchdog/ui/panels/AlertPanelContentFactory.java
+++ b/src/main/java/com/adamk33n3r/runelite/watchdog/ui/panels/AlertPanelContentFactory.java
@@ -39,6 +39,8 @@ public class AlertPanelContentFactory {
             return new StatChangedAlertPanel((StatChangedAlert) alert, onChange);
         if (alert instanceof InventoryAlert)
             return new InventoryAlertPanel((InventoryAlert) alert, onChange);
+        if (alert instanceof BankAlert)
+            return new BankAlertPanel((BankAlert) alert, onChange);
         if (alert instanceof LocationAlert)
             return new LocationAlertPanel((LocationAlert) alert, this.client, onChange);
         if (alert instanceof XPDropAlert)


### PR DESCRIPTION
Adds a Bank alert that behaves similarly to the Inventory alert, only supporting item quantities.

"Don't fire when opening the bank" will only trigger the alerts when depositing/withdrawing items from the bank

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added **Bank Alerts** to detect specific items in your bank, with support for quantity thresholds and **item change** triggering.
  - Included configurable **item matching**, **quantity comparison**, and **optional regex** patterns.
  - Added **Bank Alert** configuration panels in the Watchdog interface and enabled saving/restoring these alerts.

- **Bug Fixes**
  - Improved alert behavior by updating inventory and bank monitoring together, with more accurate item matching and change detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->