### PR TITLE
Rebuilt Herb Run alerts for per-patch selection instead of preset routes

### DIFF
--- a/herb-farming-run/README.md
+++ b/herb-farming-run/README.md
@@ -1,6 +1,6 @@
 # Fully Modular Herb Run Framework (All Patches) with Shortest Path & Chat Alerts
 
-A plug-and-play Watchdog alert-group designed for complete flexibility. 
+A customizable, menu-driven Watchdog alert group built for total route flexibility.
 
 Unlike fixed-path setups, this framework features **interconnected sub-groups for every patch location**. Since all alerts start disabled, you simply toggle on your preferred destination routes before or during your run to build a completely custom, adaptable path.
 

--- a/herb-farming-run/README.md
+++ b/herb-farming-run/README.md
@@ -1,27 +1,31 @@
-# Modular-ish Herb Run (All Tiers) with Shortest Path & Chat Alerts
+# Fully Modular Herb Run Framework (All Patches) with Shortest Path & Chat Alerts
 
-A modular alert configuration that automatically triggers **Shortest Path** navigation lines and **Game Chat Messages** to guide you from one herb patch to the next as soon as you arrive at a location.
+A plug-and-play Watchdog alert-group designed for complete flexibility. 
 
-Designed for all account types, this setup is split into togglable sub-groups depending on whether you want a step-by-step account progression run or a full Farming Guild Start.
+Unlike fixed-path setups, this framework features **interconnected sub-groups for every patch location**. Since all alerts start disabled, you simply toggle on your preferred destination routes before or during your run to build a completely custom, adaptable path.
 
-## Progression & Routes
+---
 
-### Option A: Progressive Runs (Groups 1–3)
-Ideal for low-to-mid level accounts. Toggle groups 1, 2, or 3 based on your unlocked content.
+##  Key Features
 
-* **1. Early Game (Start @ Falador):** Falador → Hosidius → Catherby → Ardougne
-* **2. Mid-Game Add-ons:** Ardougne → Morytania → Hunter Guild → Farming Guild
-* **3. Late Game / Quests:** Farming Guild → Troll Stronghold → Weiss → Harmony Island
+* **True Point-to-Point Modular Routes:** Every patch location alert-group contains routing triggers to all other patches.
+* **Flexible Start & Order:** Pick your starting patch, enable only your desired destinations, and run them in whatever order fits your needs.
+* **Visual Shortest Path Lines:** Automatically plots path lines to your chosen next destination upon arrival.
+* **Game Chat Notifications:** Clear chatbox prompts guiding your next move as soon as you step foot on a patch location.
 
-### Option B: Full Guild-Start Run (Group 4)
-Ideal for high-level accounts with all patches unlocked. Disable groups 1–3 and enable **Group 4 only**.
+---
 
-* **4. All Patches Loop (Start @ Farming Guild):** Farming Guild → Weiss → Troll Stronghold → Hosidius → Harmony Island → Morytania → Catherby → Ardougne → Falador → Hunter Guild
+##  Herb Patch Groups Breakdown
+
+Enable or disable individual Herb Patch groups based on your account progression:
+
+> **How it works:**
+> 1. Arriving at **Harmony Patch** for example, open the **"Harmony Patch"** Alert-Group and enable your next target (example **"To Catherby Patch"**).
+> 2. Once at **Catherby Patch**, open the **"Catherby Patch"** Alert-Group and enable your next destination to keep the chain going.
 
 ---
 
 ## ⚠️ Important Usage Notes
 
-* **Choose Your Mode:** Use *either* the progressive groups (1–3) OR the full farming guild start (Group 4). Do not keep both enabled at the same time to prevent conflicting path triggers.
-* **Chain Continuity:** Within any active group, do NOT disable individual location alerts. Arriving at each patch physically triggers the route to the next target. Skipping an alert will break the chain.
-* **Prevent Accidental Triggers:** Toggle off the main **"Farming Runs (Master Group)"** when not actively farming so high-traffic hubs like the Farming Guild don't accidentally start a path line while banking.
+1. **Toggle Off When Done:** Toggle off the main **"Farm run(herbs)"** when not actively farming so high-traffic areas (such as the Farming Guild) don't trigger unwanted pathing lines during daily activities. *(Alternatively, you can make the Farming Guild your final destination since that is most likely to get triggered when doing farming contracts)*
+2. **Shortest Path Plugin Required:** Ensure the **Shortest Path** plugin is installed and enabled in your RuneLite client so Watchdog can render the pathing lines.

--- a/herb-farming-run/alert.json
+++ b/herb-farming-run/alert.json
@@ -1,12 +1,12 @@
 {
-  "displayName": "Herb Run (All Patches) modular-ish",
-  "description": "Shortest Path & Game Message herb runs split into Early, Mid, Late Game, and Full Farming Guild Start groups.",
+  "displayName": "Herb Run (All Patches)",
+  "description": "Fully modular, point-to-point Shortest Path & game chat alerts for customizable herb runs.",
   "compatibleVersion": "4.0.3",
   "author": "thomasoien",
   "category": "SKILLING",
-  "tags": [ "farming", "harvest", "patch", "herb", "path", "early game", "late game" ],
+  "tags": [ "farming", "harvest", "patch", "herb", "path"],
   "dependsOn": ["Shortest Path"],
-  "alert":  {
+  "alert":   {
       "type": "AlertGroup",
       "alerts": [
         {
@@ -14,13 +14,13 @@
           "alerts": [
             {
               "type": "LocationAlert",
-              "worldPoint": { "x": 3058, "y": 3310, "plane": 0 },
+              "worldPoint": { "x": 2670, "y": 3374, "plane": 0 },
               "distance": 2,
               "repeat": false,
               "cardinalOnly": false,
-              "enabled": true,
-              "name": "[START @ FALADOR] -> Go to Hosidius",
-              "debounceTime": 30000,
+              "enabled": false,
+              "name": "To Catherby Patch",
+              "debounceTime": 5000,
               "debounceResetTime": false,
               "randomNotifications": false,
               "alertMode": "MULTI",
@@ -29,7 +29,7 @@
                   "type": "ShortestPath",
                   "mode": "PATH",
                   "useCurrentLocationForStart": true,
-                  "target": { "x": 1739, "y": 3552, "plane": 0 },
+                  "target": { "x": 2814, "y": 3464, "plane": 0 },
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -38,7 +38,7 @@
                 },
                 {
                   "type": "GameMessage",
-                  "message": "Next Location: Go to Hosidius",
+                  "message": "Next Location: Go to Catherby Patch",
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -49,13 +49,13 @@
             },
             {
               "type": "LocationAlert",
-              "worldPoint": { "x": 1739, "y": 3552, "plane": 0 },
+              "worldPoint": { "x": 2670, "y": 3374, "plane": 0 },
               "distance": 2,
               "repeat": false,
               "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Catherby",
-              "debounceTime": 30000,
+              "enabled": false,
+              "name": "To Civitas illa Fortis Patch",
+              "debounceTime": 5000,
               "debounceResetTime": false,
               "randomNotifications": false,
               "alertMode": "MULTI",
@@ -64,7 +64,7 @@
                   "type": "ShortestPath",
                   "mode": "PATH",
                   "useCurrentLocationForStart": true,
-                  "target": { "x": 2812, "y": 3463, "plane": 0 },
+                  "target": { "x": 1582, "y": 3094, "plane": 0 },
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -73,7 +73,7 @@
                 },
                 {
                   "type": "GameMessage",
-                  "message": "Next Location: Go to Catherby",
+                  "message": "Next Location: Go to Civitas illa Fortis Patch",
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -84,13 +84,13 @@
             },
             {
               "type": "LocationAlert",
-              "worldPoint": { "x": 2812, "y": 3463, "plane": 0 },
+              "worldPoint": { "x": 2670, "y": 3374, "plane": 0 },
               "distance": 2,
               "repeat": false,
               "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Ardougne",
-              "debounceTime": 30000,
+              "enabled": false,
+              "name": "To Falador Patch",
+              "debounceTime": 5000,
               "debounceResetTime": false,
               "randomNotifications": false,
               "alertMode": "MULTI",
@@ -99,7 +99,7 @@
                   "type": "ShortestPath",
                   "mode": "PATH",
                   "useCurrentLocationForStart": true,
-                  "target": { "x": 2669, "y": 3375, "plane": 0 },
+                  "target": { "x": 3058, "y": 3311, "plane": 0 },
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -108,7 +108,217 @@
                 },
                 {
                   "type": "GameMessage",
-                  "message": "Next Location: Go to Ardougne",
+                  "message": "Next Location: Go to Falador Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2670, "y": 3374, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Farming Guild Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1238, "y": 3726, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Farming Guild Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2670, "y": 3374, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Harmony Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3790, "y": 2837, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Harmony Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2670, "y": 3374, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Kourend Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1739, "y": 3551, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Kourend Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2670, "y": 3374, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Morytania Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3607, "y": 3531, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Morytania Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2670, "y": 3374, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Troll Stronghold Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2827, "y": 3694, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Troll Stronghold Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2670, "y": 3374, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Weiss Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2848, "y": 3935, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Weiss Patch",
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -118,9 +328,9 @@
               ]
             }
           ],
-          "enabled": false,
-          "name": "1. Early Game Run (Start @ Falador)",
-          "debounceTime": 0,
+          "enabled": true,
+          "name": "Ardougne Patch",
+          "debounceTime": 3000,
           "debounceResetTime": false,
           "randomNotifications": false
         },
@@ -129,13 +339,13 @@
           "alerts": [
             {
               "type": "LocationAlert",
-              "worldPoint": { "x": 2669, "y": 3375, "plane": 0 },
+              "worldPoint": { "x": 2814, "y": 3464, "plane": 0 },
               "distance": 2,
               "repeat": false,
               "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Morytania",
-              "debounceTime": 30000,
+              "enabled": false,
+              "name": "To Ardougne Patch",
+              "debounceTime": 5000,
               "debounceResetTime": false,
               "randomNotifications": false,
               "alertMode": "MULTI",
@@ -144,7 +354,7 @@
                   "type": "ShortestPath",
                   "mode": "PATH",
                   "useCurrentLocationForStart": true,
-                  "target": { "x": 3606, "y": 3530, "plane": 0 },
+                  "target": { "x": 2670, "y": 3374, "plane": 0 },
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -153,7 +363,1957 @@
                 },
                 {
                   "type": "GameMessage",
-                  "message": "Next Location: Go to Morytania",
+                  "message": "Next Location: Go to Ardougne Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2814, "y": 3464, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Civitas illa Fortis Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1582, "y": 3094, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Civitas illa Fortis Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2814, "y": 3464, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Falador Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3058, "y": 3311, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Falador Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2814, "y": 3464, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Farming Guild Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1238, "y": 3726, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Farming Guild Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2814, "y": 3464, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Harmony Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3790, "y": 2837, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Harmony Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2814, "y": 3464, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Kourend Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1739, "y": 3551, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Kourend Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2814, "y": 3464, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Morytania Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3607, "y": 3531, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Morytania Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2814, "y": 3464, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Troll Stronghold Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2827, "y": 3694, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Troll Stronghold Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2814, "y": 3464, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Weiss Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2848, "y": 3935, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Weiss Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            }
+          ],
+          "enabled": true,
+          "name": "Catherby Patch",
+          "debounceTime": 30000,
+          "debounceResetTime": false,
+          "randomNotifications": false
+        },
+        {
+          "type": "AlertGroup",
+          "alerts": [
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1582, "y": 3094, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Ardougne Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2670, "y": 3374, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Ardougne Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1582, "y": 3094, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Catherby Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2814, "y": 3464, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Catherby Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1582, "y": 3094, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Falador Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3058, "y": 3311, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Falador Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1582, "y": 3094, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Farming Guild Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1238, "y": 3726, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Farming Guild Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1582, "y": 3094, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Harmony Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3790, "y": 2837, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Harmony Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1582, "y": 3094, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Kourend Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1739, "y": 3551, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Kourend Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1582, "y": 3094, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Morytania Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3607, "y": 3531, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Morytania Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1582, "y": 3094, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Troll Stronghold Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2827, "y": 3694, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Troll Stronghold Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1582, "y": 3094, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Weiss Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2848, "y": 3935, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Weiss Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            }
+          ],
+          "enabled": true,
+          "name": "Civitas illa Fortis Patch",
+          "debounceTime": 30000,
+          "debounceResetTime": false,
+          "randomNotifications": false
+        },
+        {
+          "type": "AlertGroup",
+          "alerts": [
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3058, "y": 3311, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Ardougne Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2670, "y": 3374, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Ardougne Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3058, "y": 3311, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Catherby Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2814, "y": 3464, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Catherby Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3058, "y": 3311, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Civitas illa Fortis Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1582, "y": 3094, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Civitas illa Fortis Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3058, "y": 3311, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Farming Guild Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1238, "y": 3726, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Farming Guild Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3058, "y": 3311, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Harmony Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3790, "y": 2837, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Harmony Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3058, "y": 3311, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Kourend Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1739, "y": 3551, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Kourend Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3058, "y": 3311, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Morytania Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3607, "y": 3531, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Morytania Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3058, "y": 3311, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Troll Stronghold Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2827, "y": 3694, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Troll Stronghold Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3058, "y": 3311, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Weiss Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2848, "y": 3935, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Weiss Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            }
+          ],
+          "enabled": true,
+          "name": "Falador Patch",
+          "debounceTime": 30000,
+          "debounceResetTime": false,
+          "randomNotifications": false
+        },
+        {
+          "type": "AlertGroup",
+          "alerts": [
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Ardougne Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2670, "y": 3374, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Ardougne Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Catherby Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2814, "y": 3464, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Catherby Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Civitas illa Fortis Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1582, "y": 3094, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Civitas illa Fortis Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Falador Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3058, "y": 3311, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Falador Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Harmony Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3790, "y": 2837, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Harmony Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Kourend Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1739, "y": 3551, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Kourend Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Morytania Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3607, "y": 3531, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Morytania Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Troll Stronghold Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2827, "y": 3694, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Troll Stronghold Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Weiss Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2848, "y": 3935, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Weiss Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            }
+          ],
+          "enabled": true,
+          "name": "Farming Guild Patch",
+          "debounceTime": 30000,
+          "debounceResetTime": false,
+          "randomNotifications": false
+        },
+        {
+          "type": "AlertGroup",
+          "alerts": [
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3790, "y": 2837, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Ardougne Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2670, "y": 3374, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Ardougne Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3790, "y": 2837, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Catherby Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2814, "y": 3464, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Catherby Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3790, "y": 2837, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Civitas illa Fortis Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1582, "y": 3094, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Civitas illa Fortis Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3790, "y": 2837, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Falador Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3058, "y": 3311, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Falador Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3790, "y": 2837, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Farming Guild Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1238, "y": 3726, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Farming Guild Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3790, "y": 2837, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Kourend Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1739, "y": 3551, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Kourend Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3790, "y": 2837, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Morytania Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3607, "y": 3531, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Morytania Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3790, "y": 2837, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Troll Stronghold Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2827, "y": 3694, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Troll Stronghold Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3790, "y": 2837, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Weiss Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2848, "y": 3935, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Weiss Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            }
+          ],
+          "enabled": true,
+          "name": "Harmony Patch",
+          "debounceTime": 30000,
+          "debounceResetTime": false,
+          "randomNotifications": false
+        },
+        {
+          "type": "AlertGroup",
+          "alerts": [
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1739, "y": 3551, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Ardougne Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2670, "y": 3374, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Ardougne Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1739, "y": 3551, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Catherby Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2814, "y": 3464, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Catherby Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1739, "y": 3551, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Civitas illa Fortis Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1582, "y": 3094, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Civitas illa Fortis Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1739, "y": 3551, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Falador Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3058, "y": 3311, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Falador Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1739, "y": 3551, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Farming Guild Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1238, "y": 3726, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Farming Guild Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1739, "y": 3551, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Harmony Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3790, "y": 2837, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Harmony Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1739, "y": 3551, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Morytania Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3607, "y": 3531, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Morytania Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1739, "y": 3551, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Troll Stronghold Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2827, "y": 3694, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Troll Stronghold Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 1739, "y": 3551, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Weiss Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2848, "y": 3935, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Weiss Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            }
+          ],
+          "enabled": true,
+          "name": "Kourend Patch",
+          "debounceTime": 30000,
+          "debounceResetTime": false,
+          "randomNotifications": false
+        },
+        {
+          "type": "AlertGroup",
+          "alerts": [
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3606, "y": 3530, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Ardougne Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2670, "y": 3374, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Ardougne Patch",
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -168,9 +2328,9 @@
               "distance": 2,
               "repeat": false,
               "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Hunter Guild",
-              "debounceTime": 30000,
+              "enabled": false,
+              "name": "To Catherby Patch",
+              "debounceTime": 5000,
               "debounceResetTime": false,
               "randomNotifications": false,
               "alertMode": "MULTI",
@@ -179,7 +2339,7 @@
                   "type": "ShortestPath",
                   "mode": "PATH",
                   "useCurrentLocationForStart": true,
-                  "target": { "x": 1583, "y": 3094, "plane": 0 },
+                  "target": { "x": 2814, "y": 3464, "plane": 0 },
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -188,342 +2348,7 @@
                 },
                 {
                   "type": "GameMessage",
-                  "message": "Next Location: Go to Hunter Guild",
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                }
-              ]
-            },
-            {
-              "type": "LocationAlert",
-              "worldPoint": { "x": 1583, "y": 3094, "plane": 0 },
-              "distance": 2,
-              "repeat": false,
-              "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Farming Guild",
-              "debounceTime": 30000,
-              "debounceResetTime": false,
-              "randomNotifications": false,
-              "alertMode": "MULTI",
-              "notifications": [
-                {
-                  "type": "ShortestPath",
-                  "mode": "PATH",
-                  "useCurrentLocationForStart": true,
-                  "target": { "x": 1239, "y": 3728, "plane": 0 },
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                },
-                {
-                  "type": "GameMessage",
-                  "message": "Next Location: Go to Farming Guild",
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                }
-              ]
-            }
-          ],
-          "enabled": false,
-          "name": "2. Mid Game Add-ons",
-          "debounceTime": 0,
-          "debounceResetTime": false,
-          "randomNotifications": false
-        },
-        {
-          "type": "AlertGroup",
-          "alerts": [
-            {
-              "type": "LocationAlert",
-              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
-              "distance": 2,
-              "repeat": false,
-              "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Troll Stronghold",
-              "debounceTime": 30000,
-              "debounceResetTime": false,
-              "randomNotifications": false,
-              "alertMode": "MULTI",
-              "notifications": [
-                {
-                  "type": "ShortestPath",
-                  "mode": "PATH",
-                  "useCurrentLocationForStart": true,
-                  "target": { "x": 2828, "y": 3694, "plane": 0 },
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                },
-                {
-                  "type": "GameMessage",
-                  "message": "Next Location: Go to Troll Stronghold",
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                }
-              ]
-            },
-            {
-              "type": "LocationAlert",
-              "worldPoint": { "x": 2828, "y": 3694, "plane": 0 },
-              "distance": 2,
-              "repeat": false,
-              "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Weiss",
-              "debounceTime": 30000,
-              "debounceResetTime": false,
-              "randomNotifications": false,
-              "alertMode": "MULTI",
-              "notifications": [
-                {
-                  "type": "ShortestPath",
-                  "mode": "PATH",
-                  "useCurrentLocationForStart": true,
-                  "target": { "x": 2847, "y": 3935, "plane": 0 },
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                },
-                {
-                  "type": "GameMessage",
-                  "message": "Next Location: Go to Weiss",
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                }
-              ]
-            },
-            {
-              "type": "LocationAlert",
-              "worldPoint": { "x": 2847, "y": 3935, "plane": 0 },
-              "distance": 2,
-              "repeat": false,
-              "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Harmony Island",
-              "debounceTime": 30000,
-              "debounceResetTime": false,
-              "randomNotifications": false,
-              "alertMode": "MULTI",
-              "notifications": [
-                {
-                  "type": "ShortestPath",
-                  "mode": "PATH",
-                  "useCurrentLocationForStart": true,
-                  "target": { "x": 3790, "y": 2839, "plane": 0 },
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                },
-                {
-                  "type": "GameMessage",
-                  "message": "Next Location: Go to Harmony Island",
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                }
-              ]
-            }
-          ],
-          "enabled": false,
-          "name": "3. Late Game / High Quests",
-          "debounceTime": 0,
-          "debounceResetTime": false,
-          "randomNotifications": false
-        },
-        {
-          "type": "AlertGroup",
-          "alerts": [
-            {
-              "type": "LocationAlert",
-              "worldPoint": { "x": 1238, "y": 3726, "plane": 0 },
-              "distance": 2,
-              "repeat": false,
-              "cardinalOnly": false,
-              "enabled": true,
-              "name": "[START @ FARMING GUILD] -> Go to Weiss",
-              "debounceTime": 30000,
-              "debounceResetTime": false,
-              "randomNotifications": false,
-              "alertMode": "MULTI",
-              "notifications": [
-                {
-                  "type": "ShortestPath",
-                  "mode": "PATH",
-                  "useCurrentLocationForStart": true,
-                  "target": { "x": 2847, "y": 3935, "plane": 0 },
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                },
-                {
-                  "type": "GameMessage",
-                  "message": "Next Location: Go to Weiss",
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                }
-              ]
-            },
-            {
-              "type": "LocationAlert",
-              "worldPoint": { "x": 2847, "y": 3935, "plane": 0 },
-              "distance": 2,
-              "repeat": false,
-              "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Troll Stronghold",
-              "debounceTime": 30000,
-              "debounceResetTime": false,
-              "randomNotifications": false,
-              "alertMode": "MULTI",
-              "notifications": [
-                {
-                  "type": "ShortestPath",
-                  "mode": "PATH",
-                  "useCurrentLocationForStart": true,
-                  "target": { "x": 2828, "y": 3694, "plane": 0 },
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                },
-                {
-                  "type": "GameMessage",
-                  "message": "Next Location: Go to Troll Stronghold",
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                }
-              ]
-            },
-            {
-              "type": "LocationAlert",
-              "worldPoint": { "x": 2828, "y": 3694, "plane": 0 },
-              "distance": 2,
-              "repeat": false,
-              "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Hosidius",
-              "debounceTime": 30000,
-              "debounceResetTime": false,
-              "randomNotifications": false,
-              "alertMode": "MULTI",
-              "notifications": [
-                {
-                  "type": "ShortestPath",
-                  "mode": "PATH",
-                  "useCurrentLocationForStart": true,
-                  "target": { "x": 1739, "y": 3552, "plane": 0 },
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                },
-                {
-                  "type": "GameMessage",
-                  "message": "Next Location: Go to Hosidius",
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                }
-              ]
-            },
-            {
-              "type": "LocationAlert",
-              "worldPoint": { "x": 1739, "y": 3552, "plane": 0 },
-              "distance": 2,
-              "repeat": false,
-              "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Harmony Island",
-              "debounceTime": 30000,
-              "debounceResetTime": false,
-              "randomNotifications": false,
-              "alertMode": "MULTI",
-              "notifications": [
-                {
-                  "type": "ShortestPath",
-                  "mode": "PATH",
-                  "useCurrentLocationForStart": true,
-                  "target": { "x": 3790, "y": 2839, "plane": 0 },
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                },
-                {
-                  "type": "GameMessage",
-                  "message": "Next Location: Go to Harmony Island",
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                }
-              ]
-            },
-            {
-              "type": "LocationAlert",
-              "worldPoint": { "x": 3790, "y": 2839, "plane": 0 },
-              "distance": 2,
-              "repeat": false,
-              "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Morytania",
-              "debounceTime": 30000,
-              "debounceResetTime": false,
-              "randomNotifications": false,
-              "alertMode": "MULTI",
-              "notifications": [
-                {
-                  "type": "ShortestPath",
-                  "mode": "PATH",
-                  "useCurrentLocationForStart": true,
-                  "target": { "x": 3606, "y": 3530, "plane": 0 },
-                  "enabled": true,
-                  "fireWhenFocused": true,
-                  "fireWhenAFK": false,
-                  "fireWhenAFKForSeconds": 5,
-                  "delayMilliseconds": 0
-                },
-                {
-                  "type": "GameMessage",
-                  "message": "Next Location: Go to Morytania",
+                  "message": "Next Location: Go to Catherby Patch",
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -538,9 +2363,9 @@
               "distance": 2,
               "repeat": false,
               "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Catherby",
-              "debounceTime": 30000,
+              "enabled": false,
+              "name": "To Civitas illa Fortis Patch",
+              "debounceTime": 5000,
               "debounceResetTime": false,
               "randomNotifications": false,
               "alertMode": "MULTI",
@@ -549,7 +2374,7 @@
                   "type": "ShortestPath",
                   "mode": "PATH",
                   "useCurrentLocationForStart": true,
-                  "target": { "x": 2812, "y": 3463, "plane": 0 },
+                  "target": { "x": 1582, "y": 3094, "plane": 0 },
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -558,7 +2383,7 @@
                 },
                 {
                   "type": "GameMessage",
-                  "message": "Next Location: Go to Catherby",
+                  "message": "Next Location: Go to Civitas illa Fortis Patch",
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -569,13 +2394,13 @@
             },
             {
               "type": "LocationAlert",
-              "worldPoint": { "x": 2812, "y": 3463, "plane": 0 },
+              "worldPoint": { "x": 3606, "y": 3530, "plane": 0 },
               "distance": 2,
               "repeat": false,
               "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Ardougne",
-              "debounceTime": 30000,
+              "enabled": false,
+              "name": "To Falador Patch",
+              "debounceTime": 5000,
               "debounceResetTime": false,
               "randomNotifications": false,
               "alertMode": "MULTI",
@@ -584,7 +2409,7 @@
                   "type": "ShortestPath",
                   "mode": "PATH",
                   "useCurrentLocationForStart": true,
-                  "target": { "x": 2669, "y": 3375, "plane": 0 },
+                  "target": { "x": 3058, "y": 3311, "plane": 0 },
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -593,7 +2418,7 @@
                 },
                 {
                   "type": "GameMessage",
-                  "message": "Next Location: Go to Ardougne",
+                  "message": "Next Location: Go to Falador Patch",
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -604,13 +2429,13 @@
             },
             {
               "type": "LocationAlert",
-              "worldPoint": { "x": 2669, "y": 3375, "plane": 0 },
+              "worldPoint": { "x": 3606, "y": 3530, "plane": 0 },
               "distance": 2,
               "repeat": false,
               "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Falador",
-              "debounceTime": 30000,
+              "enabled": false,
+              "name": "To Farming Guild Patch",
+              "debounceTime": 5000,
               "debounceResetTime": false,
               "randomNotifications": false,
               "alertMode": "MULTI",
@@ -619,7 +2444,7 @@
                   "type": "ShortestPath",
                   "mode": "PATH",
                   "useCurrentLocationForStart": true,
-                  "target": { "x": 3058, "y": 3310, "plane": 0 },
+                  "target": { "x": 1238, "y": 3726, "plane": 0 },
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -628,7 +2453,7 @@
                 },
                 {
                   "type": "GameMessage",
-                  "message": "Next Location: Go to Falador",
+                  "message": "Next Location: Go to Farming Guild Patch",
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -639,13 +2464,13 @@
             },
             {
               "type": "LocationAlert",
-              "worldPoint": { "x": 3058, "y": 3310, "plane": 0 },
+              "worldPoint": { "x": 3606, "y": 3530, "plane": 0 },
               "distance": 2,
               "repeat": false,
               "cardinalOnly": false,
-              "enabled": true,
-              "name": "Go to Hunter Guild",
-              "debounceTime": 30000,
+              "enabled": false,
+              "name": "To Harmony Patch",
+              "debounceTime": 5000,
               "debounceResetTime": false,
               "randomNotifications": false,
               "alertMode": "MULTI",
@@ -654,7 +2479,7 @@
                   "type": "ShortestPath",
                   "mode": "PATH",
                   "useCurrentLocationForStart": true,
-                  "target": { "x": 1583, "y": 3094, "plane": 0 },
+                  "target": { "x": 3790, "y": 2837, "plane": 0 },
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -663,7 +2488,112 @@
                 },
                 {
                   "type": "GameMessage",
-                  "message": "Next Location: Go to Hunter Guild",
+                  "message": "Next Location: Go to Harmony Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3606, "y": 3530, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Kourend Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1739, "y": 3551, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Kourend Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3606, "y": 3530, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Troll Stronghold Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2827, "y": 3694, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Troll Stronghold Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 3606, "y": 3530, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Weiss Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2848, "y": 3935, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Weiss Patch",
                   "enabled": true,
                   "fireWhenFocused": true,
                   "fireWhenAFK": false,
@@ -673,16 +2603,666 @@
               ]
             }
           ],
-          "enabled": false,
-          "name": "4. All Patches (Start @ Farming Guild)",
-          "debounceTime": 0,
+          "enabled": true,
+          "name": "Morytania Patch",
+          "debounceTime": 30000,
+          "debounceResetTime": false,
+          "randomNotifications": false
+        },
+        {
+          "type": "AlertGroup",
+          "alerts": [
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2827, "y": 3694, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Ardougne Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2670, "y": 3374, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Ardougne Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2827, "y": 3694, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Catherby Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2814, "y": 3464, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Catherby Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2827, "y": 3694, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Civitas illa Fortis Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1582, "y": 3094, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Civitas illa Fortis Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2827, "y": 3694, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Falador Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3058, "y": 3311, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Falador Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2827, "y": 3694, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Farming Guild Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1238, "y": 3726, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Farming Guild Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2827, "y": 3694, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Harmony Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3790, "y": 2837, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Harmony Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2827, "y": 3694, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Kourend Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1739, "y": 3551, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Kourend Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2827, "y": 3694, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Morytania Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3607, "y": 3531, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Morytania Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2827, "y": 3694, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Weiss Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2848, "y": 3935, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Weiss Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            }
+          ],
+          "enabled": true,
+          "name": "Troll Stronghold Patch",
+          "debounceTime": 30000,
+          "debounceResetTime": false,
+          "randomNotifications": false
+        },
+        {
+          "type": "AlertGroup",
+          "alerts": [
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2848, "y": 3935, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Ardougne Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2670, "y": 3374, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Ardougne Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2848, "y": 3935, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Catherby Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2814, "y": 3464, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Catherby Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2848, "y": 3935, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Civitas illa Fortis Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1582, "y": 3094, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Civitas illa Fortis Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2848, "y": 3935, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Falador Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3058, "y": 3311, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Falador Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2848, "y": 3935, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Farming Guild Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1238, "y": 3726, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Farming Guild Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2848, "y": 3935, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Harmony Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3790, "y": 2837, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Harmony Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2848, "y": 3935, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Kourend Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 1739, "y": 3551, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Kourend Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2848, "y": 3935, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Morytania Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 3607, "y": 3531, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Morytania Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            },
+            {
+              "type": "LocationAlert",
+              "worldPoint": { "x": 2848, "y": 3935, "plane": 0 },
+              "distance": 2,
+              "repeat": false,
+              "cardinalOnly": false,
+              "enabled": false,
+              "name": "To Troll Stronghold Patch",
+              "debounceTime": 5000,
+              "debounceResetTime": false,
+              "randomNotifications": false,
+              "alertMode": "MULTI",
+              "notifications": [
+                {
+                  "type": "ShortestPath",
+                  "mode": "PATH",
+                  "useCurrentLocationForStart": true,
+                  "target": { "x": 2827, "y": 3694, "plane": 0 },
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                },
+                {
+                  "type": "GameMessage",
+                  "message": "Next Location: Go to Troll Stronghold Patch",
+                  "enabled": true,
+                  "fireWhenFocused": true,
+                  "fireWhenAFK": false,
+                  "fireWhenAFKForSeconds": 5,
+                  "delayMilliseconds": 0
+                }
+              ]
+            }
+          ],
+          "enabled": true,
+          "name": "Weiss Patch",
+          "debounceTime": 30000,
           "debounceResetTime": false,
           "randomNotifications": false
         }
       ],
       "enabled": true,
-      "name": "herb farm run modular-ish",
-      "debounceTime": 0,
+      "name": "Farm run (Herbs)",
+      "debounceTime": 5000,
       "debounceResetTime": false,
       "randomNotifications": false
     }


### PR DESCRIPTION
Scrapped and remade the Herb Run alerts from scratch. I wasn't happy with how the previous version turned out, so I rebuilt the setup to be fully modular instead of relying on a few hard-coded routes.

If you think this is too large or if previous version is fine as is, you can just decline the pull request      ¯\\_(ツ)_/¯

## What Changed
- **Rebuilt Alert Setup:** Removed the old hard-coded route selections and replaced them with individual alert groups for each patch.
-  **Flexible Destinations:** You can now select your exact destination patch within each alert group instead of being locked into a set route.